### PR TITLE
block/006: added checking if null_blk has blocking flag

### DIFF
--- a/tests/block/006
+++ b/tests/block/006
@@ -24,7 +24,7 @@ DESCRIPTION="run null-blk in blocking mode"
 TIMED=1
 
 requires() {
-	_have_module null_blk
+	_have_module null_blk && _have_module_param null_blk blocking
 }
 
 test() {


### PR DESCRIPTION
There is no 'blocking' parameter on some branches, eg. RHEL7.

Signed-off-by: Xiao Liang <xiliang@redhat.com>