### PR TITLE
block/006, block/008, block/010: add _have_fio to require function

### DIFF
--- a/tests/block/006
+++ b/tests/block/006
@@ -24,7 +24,7 @@ DESCRIPTION="run null-blk in blocking mode"
 TIMED=1
 
 requires() {
-	_have_module null_blk && _have_module_param null_blk blocking
+	_have_module null_blk && _have_module_param null_blk blocking && _have_fio
 }
 
 test() {

--- a/tests/block/008
+++ b/tests/block/008
@@ -23,7 +23,7 @@ DESCRIPTION="do IO while hotplugging CPUs"
 TIMED=1
 
 requires() {
-	_have_cpu_hotplug
+	_have_cpu_hotplug && _have_fio
 }
 
 test_device() {

--- a/tests/block/010
+++ b/tests/block/010
@@ -24,7 +24,7 @@ DESCRIPTION="run I/O on null_blk with shared and non-shared tags"
 TIMED=1
 
 requires() {
-	_have_module null_blk && _have_module_param null_blk shared_tags
+	_have_module null_blk && _have_module_param null_blk shared_tags && _have_fio
 }
 
 run_fio_job() {


### PR DESCRIPTION
Add the missed _have_fio for block/006, block/008, block/010

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>