### PR TITLE
dir-locals.el: add emacs local variable config

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((sh-mode . ((sh-basic-offset . 8)
+	     (fill-column . 80)
+	     (indent-tabs-mode . t))))


### PR DESCRIPTION
Add a dir-locals.el so Emacs will do the right thing when editing
blktests code and test cases.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>