### PR TITLE
nvme: don't require nvme devices for the whole group

### DIFF
--- a/tests/nvme/001
+++ b/tests/nvme/001
@@ -26,6 +26,10 @@ requires() {
 	_have_tracefs && _have_tracepoint "nvme/nvme_setup_nvm_cmd"
 }
 
+device_requires() {
+	_test_dev_is_nvme
+}
+
 filter_trace() {
 	sed -r -e  's/dd-[0-9]+/dd-XXX/' \
 		-e 's/\[[0-9]+\]/[XXX]/' \

--- a/tests/nvme/group
+++ b/tests/nvme/group
@@ -22,7 +22,3 @@
 group_requires() {
 	_have_root
 }
-
-group_device_requires() {
-	_test_dev_is_nvme
-}


### PR DESCRIPTION
Currently the nvme group requires nvme devices, but only one test
currently targets nvme devices the other tests create the devices
themselves using the loopback target.

Remove the group_device_requires() _test_dev_is_nvme to a simple
device_requires() in test/nvme/001.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>