### PR TITLE
Add partition table handling test

### DIFF
--- a/common/nbd
+++ b/common/nbd
@@ -44,5 +44,6 @@ EOF
 
 _stop_nbd_server() {
 	kill -SIGTERM "$(cat "${TMPDIR}/nbd.pid")"
+	rm -f "${TMPDIR}/nbd.pid"
 	rm -f "${TMPDIR}/export"
 }

--- a/common/nbd
+++ b/common/nbd
@@ -32,6 +32,30 @@ _have_nbd_netlink() {
 	_have_nbd && _have_nbd_netlink_support
 }
 
+_wait_for_nbd_connect() {
+	_ret=1
+	for i in $(seq  0 3); do
+		if [ -e /sys/kernel/debug/nbd/nbd0/tasks ]; then
+			_ret=0
+			break
+		fi
+		sleep 1
+	done
+	return $_ret
+}
+
+_wait_for_nbd_disconnect() {
+	_ret=1
+	for i in $(seq  0 3); do
+		if [ ! -e /sys/kernel/debug/nbd/nbd0/tasks ]; then
+			_ret=0
+			break
+		fi
+		sleep 1
+	done
+	return $_ret
+}
+
 _start_nbd_server() {
 	truncate -s 10G "${TMPDIR}/export"
 	cat > "${TMPDIR}/nbd.conf" << EOF

--- a/tests/nbd/002
+++ b/tests/nbd/002
@@ -1,6 +1,13 @@
 #!/bin/bash
 #
-# Test nbd device resizing.
+# Test nbd device resizing, regression test for the following fixes
+#
+# nbd: fix nbd device deletion
+# nbd: update size when connected
+# nbd: use bd_set_size when updating disk size
+# nbd: clear_sock on netlink disconnect
+# nbd: fix how we set bd_invalidated
+# nbd: call nbd_bdev_reset instead of bd_set_size on disconnect
 #
 # Copyright (C) 2018 Josef Bacik
 #

--- a/tests/nbd/002
+++ b/tests/nbd/002
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Test nbd device resizing.
+#
+# Copyright (C) 2018 Josef Bacik
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+. common/nbd
+
+DESCRIPTION="tests on partition handling for an nbd device"
+QUICK=1
+
+requires() {
+	_have_nbd_netlink && _have_program parted
+}
+
+
+test() {
+	echo "Running ${TEST_NAME}"
+	_start_nbd_server
+	nbd-client -N export localhost /dev/nbd0 > /dev/null 2>&1
+
+	parted -s /dev/nbd0 mklabel msdos > /dev/null 2>&1
+	parted -s /dev/nbd0 mkpart primary 0 100 > /dev/null 2>&1
+
+	~/nbd/nbd-client -d /dev/nbd0 > /dev/null 2>&1
+
+	if ! _wait_for_nbd_disconnect; then
+		echo "Disonnect didn't happen?" >> /dev/kmsg
+		_stop_nbd_server
+		return 1
+	fi
+
+	# We do this to make sure the parition table is rescanned properly,
+	# otherwise we'd have to do a sleep 5 to make sure we gave udev enough
+	# time to notice the uevent.  It would be great to integrate uevent
+	# tests into there to make sure we're doing the right thing.
+	stat /dev/nbd0 > /dev/null 2>&1
+
+	if stat /dev/nbd0p1 > /dev/null 2>&1; then
+		echo "Had partition after disconnect?"
+		_stop_nbd_server
+		return 1
+	fi
+
+	# Do it with ioctls
+
+	echo "Testing IOCTL path"
+
+	nbd-client -N export localhost /dev/nbd0 > /dev/null 2>&1
+
+	if ! _wait_for_nbd_connect; then
+		echo "Connect didn't happen?"
+		nbd-client -d /dev/nbd0 > /dev/null 2>&1
+		_stop_nbd_server
+		return 1
+	fi
+
+	stat /dev/nbd0 > /dev/null 2>&1
+
+	if ! stat /dev/nbd0p1 > /dev/null 2>&1; then
+		echo "Didn't have partition on ioctl path"
+		nbd-client -d /dev/nbd0 > /dev/null 2>&1
+		_stop_nbd_server
+		return 1
+	fi
+
+	nbd-client -d /dev/nbd0 > /dev/null 2>&1
+
+	stat /dev/nbd0 > /dev/null 2>&1
+
+	if stat /dev/nbd0p1 > /dev/null 2>&1; then
+		echo "Partition still exists after disconnect"
+		_stop_nbd_server
+		return 1
+	fi
+
+	# Do it with netlink
+	echo "Testing the netlink path"
+	nbd-client -L -N export localhost /dev/nbd0 > /dev/null 2>&1
+
+	if ! _wait_for_nbd_connect; then
+		echo "Connect didn't happen?"
+		nbd-client -d /dev/nbd0 > /dev/null 2>&1
+		_stop_nbd_server
+		return 1
+	fi
+
+	stat /dev/nbd0 > /dev/null 2>&1
+
+	if  ! stat /dev/nbd0p1 >/dev/null 2>&1; then
+		echo "Didn't have parition on the netlink path"
+		nbd-client -L -d /dev/nbd0 > /dev/null 2>&1
+		_stop_nbd_server
+		return 1
+	fi
+
+	nbd-client -L -d /dev/nbd0 > /dev/null 2>&1
+
+	if ! _wait_for_nbd_disconnect; then
+		echo "Disonnect didn't happen?" >> /dev/kmsg
+		_stop_nbd_server
+		return 1
+	fi
+
+	stat /dev/nbd0 > /dev/null 2>&1
+
+	if stat /dev/nbd0p1 > /dev/null 2>&1; then
+		echo "Partition still exists after netlink disconnect"
+		_stop_nbd_server
+		return 1
+	fi
+
+	echo "Test complete"
+	_stop_nbd_server
+	return 0
+}

--- a/tests/nbd/002.out
+++ b/tests/nbd/002.out
@@ -1,0 +1,4 @@
+Running nbd/002
+Testing IOCTL path
+Testing the netlink path
+Test complete


### PR DESCRIPTION
Adds some more infrastructure for making sure we don't race with connect/disconnect with NBD for things that require appropriate timing, and then add a test to make sure we handle creating and deleting the partition tables properly.  This will fail without the kernel patches that I'm going to send upstream, so keep that in mind.