### PR TITLE
nvme/001: fix filter and golden output

### DIFF
--- a/tests/nvme/001
+++ b/tests/nvme/001
@@ -28,12 +28,14 @@ requires() {
 
 filter_trace() {
 	sed -r -e  's/dd-[0-9]+/dd-XXX/' \
+		-e 's/X\s+\[/X	 [/' \
 		-e 's/\[[0-9]+\]/[XXX]/' \
-		-e 's/\.{4}\s+/....    /' \
+		-e 's/[0-9\.]{4}\s+/....	/' \
 		-e 's/[0-9]+\.[0-9]+/X.XXXXXX/' \
 		-e 's/qid=[0-9-]+/qid=X/' \
 		-e 's/nsid=[0-9-]+/nsid=X/' \
-		-e 's/cmdid=[0-9-]+/cmdid=X/'
+		-e 's/cmdid=[0-9-]+/cmdid=X/' \
+		-e 's/slba=[0-9]+/slba=X/'
 }
 
 test_device() {

--- a/tests/nvme/001.out
+++ b/tests/nvme/001.out
@@ -8,5 +8,5 @@ Running nvme/001
 #                            ||| /     delay
 #           TASK-PID   CPU#  ||||    TIMESTAMP  FUNCTION
 #              | |       |   ||||       |         |
-              dd-XXX   [XXX] ....    X.XXXXXX: nvme_setup_nvm_cmd: qid=X, nsid=X, cmdid=X, flags=0x0, meta=0x0, cmd=(nvme_cmd_read slba=0, len=0, ctrl=0x0, dsmgmt=0, reftag=0)
+              dd-XXX   [XXX] ....    X.XXXXXX: nvme_setup_nvm_cmd: qid=X, nsid=X, cmdid=X, flags=0x0, meta=0x0, cmd=(nvme_cmd_read slba=X, len=0, ctrl=0x0, dsmgmt=0, reftag=0)
 Test complete


### PR DESCRIPTION
Adjust filter and golden output to consider the following:
* Normalize white space between PID and CPU#
* Nomalize flags
* Normalize slba

This fixes issue #21.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>