### PR TITLE
settle udev before unloading null_blk

### DIFF
--- a/common/null_blk
+++ b/common/null_blk
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# null_blk helper functions.
+#
+# Copyright (C) 2017 Omar Sandoval
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+_have_null_blk() {
+	_have_module null_blk
+}
+
+_init_null_blk() {
+	if ! modprobe -r null_blk || ! modprobe null_blk "$@"; then
+		return 1
+	fi
+
+	udevadm settle
+	return 0
+}
+
+_exit_null_blk() {
+	udevadm settle
+	modprobe -r null_blk
+}

--- a/tests/block/006
+++ b/tests/block/006
@@ -21,12 +21,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="run null-blk in blocking mode"
 TIMED=1
 
 requires() {
-	_have_module null_blk && _have_module_param null_blk blocking && _have_fio
+	_have_null_blk && _have_module_param null_blk blocking && _have_fio
 }
 
 test() {
@@ -35,8 +36,7 @@ test() {
 	_divide_timeout 2
 	FIO_PERF_FIELDS=("read iops")
 
-	modprobe -r null_blk
-	if ! modprobe null_blk queue_mode=2 submit_queues=2 blocking=1; then
+	if ! _init_null_blk queue_mode=2 submit_queues=2 blocking=1; then
 		return 1
 	fi
 
@@ -49,8 +49,7 @@ test() {
 		--rw=randread --norandommap --name=async \
 		--filename=/dev/nullb0 --size=5g --direct=1
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 
 	echo "Test complete"
 }

--- a/tests/block/006
+++ b/tests/block/006
@@ -49,6 +49,7 @@ test() {
 		--rw=randread --norandommap --name=async \
 		--filename=/dev/nullb0 --size=5g --direct=1
 
+	udevadm settle
 	modprobe -r null_blk
 
 	echo "Test complete"

--- a/tests/block/010
+++ b/tests/block/010
@@ -69,6 +69,7 @@ test() {
 	FIO_PERF_FIELDS=("read iops")
 	run_fio_job
 
+	udevadm settle
 	modprobe -r null_blk
 	if ! modprobe null_blk queue_mode=2 submit_queues=16 nr_devices=32 shared_tags=1; then
 		return 1
@@ -78,6 +79,7 @@ test() {
 	FIO_PERF_FIELDS=("read iops")
 	run_fio_job
 
+	udevadm settle
 	modprobe -r null_blk
 	echo "Test complete"
 }

--- a/tests/block/010
+++ b/tests/block/010
@@ -21,12 +21,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="run I/O on null_blk with shared and non-shared tags"
 TIMED=1
 
 requires() {
-	_have_module null_blk && _have_module_param null_blk shared_tags && _have_fio
+	_have_null_blk && _have_module_param null_blk shared_tags && _have_fio
 }
 
 run_fio_job() {
@@ -60,8 +61,7 @@ test() {
 
 	_divide_timeout 2
 
-	modprobe -r null_blk
-	if ! modprobe null_blk queue_mode=2 submit_queues=16 nr_devices=32; then
+	if ! _init_null_blk queue_mode=2 submit_queues=16 nr_devices=32; then
 		return 1
 	fi
 
@@ -69,9 +69,8 @@ test() {
 	FIO_PERF_FIELDS=("read iops")
 	run_fio_job
 
-	udevadm settle
-	modprobe -r null_blk
-	if ! modprobe null_blk queue_mode=2 submit_queues=16 nr_devices=32 shared_tags=1; then
+	_exit_null_blk
+	if ! _init_null_blk queue_mode=2 submit_queues=16 nr_devices=32 shared_tags=1; then
 		return 1
 	fi
 
@@ -79,7 +78,6 @@ test() {
 	FIO_PERF_FIELDS=("read iops")
 	run_fio_job
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 	echo "Test complete"
 }

--- a/tests/block/014
+++ b/tests/block/014
@@ -18,21 +18,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="run null-blk with blk-mq and timeout injection configured"
 
 requires() {
-	_have_module null-blk && _have_module_param null_blk timeout
+	_have_null_blk && _have_module_param null_blk timeout
 }
 
 test() {
 	echo "Running ${TEST_NAME}"
 
-	modprobe -r null_blk
-
 	# The format is "<interval>,<probability>,<space>,<times>". Here, we
 	# fail 50% of I/Os.
-	modprobe null_blk queue_mode=2 timeout='1,50,0,-1'
+	if ! _init_null_blk queue_mode=2 timeout='1,50,0,-1'; then
+		return 1
+	fi
 
 	local scheds
 	# shellcheck disable=SC2207
@@ -51,8 +52,7 @@ test() {
 		wait
 	done
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 
 	echo "Test complete"
 }

--- a/tests/block/014
+++ b/tests/block/014
@@ -51,6 +51,7 @@ test() {
 		wait
 	done
 
+	udevadm settle
 	modprobe -r null_blk
 
 	echo "Test complete"

--- a/tests/block/015
+++ b/tests/block/015
@@ -19,22 +19,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="run null-blk on different schedulers with requeue injection configured"
 QUICK=1
 
 requires() {
-	_have_module null-blk && _have_module_param null_blk requeue
+	_have_null_blk && _have_module_param null_blk requeue
 }
 
 test() {
 	echo "Running ${TEST_NAME}"
 
-	modprobe -r null_blk
-
 	# The format is "<interval>,<probability>,<space>,<times>". Here, we
 	# requeue 10% of the time.
-	modprobe null_blk queue_mode=2 requeue='1,10,0,-1'
+	if ! _init_null_blk queue_mode=2 requeue='1,10,0,-1'; then
+		return 1
+	fi
 
 	local scheds
 	# shellcheck disable=SC2207
@@ -47,8 +48,7 @@ test() {
 			iflag=direct status=none
 	done
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 
 	echo "Test complete"
 }

--- a/tests/block/015
+++ b/tests/block/015
@@ -47,6 +47,7 @@ test() {
 			iflag=direct status=none
 	done
 
+	udevadm settle
 	modprobe -r null_blk
 
 	echo "Test complete"

--- a/tests/block/016
+++ b/tests/block/016
@@ -53,6 +53,7 @@ test() {
 	kill -USR1 $!
 	wait
 
+	udevadm settle
 	modprobe -r null_blk
 
 	echo "Test complete"

--- a/tests/block/016
+++ b/tests/block/016
@@ -20,20 +20,21 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="send a signal to a process waiting on a frozen queue"
 QUICK=1
 
 requires() {
-	_have_module null_blk
+	_have_null_blk
 }
 
 test() {
 	echo "Running ${TEST_NAME}"
 
-	modprobe -r null_blk
-
-	modprobe null_blk queue_mode=2 irqmode=2 completion_nsec=2000000000
+	if ! _init_null_blk null_blk queue_mode=2 irqmode=2 completion_nsec=2000000000; then
+		return 1
+	fi
 
 	# Start an I/O, which will take two seconds.
 	dd if=/dev/nullb0 of=/dev/null bs=512 iflag=direct count=1 status=none &
@@ -53,8 +54,7 @@ test() {
 	kill -USR1 $!
 	wait
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 
 	echo "Test complete"
 }

--- a/tests/block/017
+++ b/tests/block/017
@@ -58,6 +58,7 @@ test() {
 		wait
 		show_inflight
 
+		udevadm settle
 		modprobe -r null_blk
 	done
 

--- a/tests/block/017
+++ b/tests/block/017
@@ -20,12 +20,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="do I/O and check the inflight counter"
 QUICK=1
 
 requires() {
-	_have_module null_blk
+	_have_null_blk
 }
 
 show_inflight() {
@@ -41,11 +42,10 @@ test() {
 	for ((queue_mode = 1; queue_mode <= 2; queue_mode++)) do
 		echo "queue mode $queue_mode"
 
-		modprobe -r null_blk
-		modprobe null_blk queue_mode="$queue_mode" irqmode=2 \
-			completion_nsec=500000000 || continue
-
-		udevadm settle
+		if ! _init_null_blk queue_mode="$queue_mode" irqmode=2 \
+		     completion_nsec=500000000; then
+			continue
+		fi
 
 		dd if=/dev/nullb0 of=/dev/null bs=4096 iflag=direct count=1 status=none &
 		sleep 0.1
@@ -58,8 +58,7 @@ test() {
 		wait
 		show_inflight
 
-		udevadm settle
-		modprobe -r null_blk
+		_exit_null_blk
 	done
 
 	echo "Test complete"

--- a/tests/block/018
+++ b/tests/block/018
@@ -69,6 +69,7 @@ test() {
 		wait
 		show_times
 
+		udevadm settle
 		modprobe -r null_blk
 
 		unset init_read_ms init_write_ms read_ms write_ms

--- a/tests/block/018
+++ b/tests/block/018
@@ -18,12 +18,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="do I/O and check iostats times"
 QUICK=1
 
 requires() {
-	_have_module null_blk
+	_have_null_blk
 }
 
 init_times() {
@@ -48,9 +49,10 @@ test() {
 
 		echo "queue mode $queue_mode"
 
-		modprobe -r null_blk
-		modprobe null_blk queue_mode="$queue_mode" irqmode=2 \
-			completion_nsec=1000000000 || continue
+		if ! modprobe null_blk queue_mode="$queue_mode" irqmode=2 \
+		     completion_nsec=1000000000; then
+			continue
+		fi
 
 		udevadm settle
 
@@ -69,8 +71,7 @@ test() {
 		wait
 		show_times
 
-		udevadm settle
-		modprobe -r null_blk
+		_exit_null_blk
 
 		unset init_read_ms init_write_ms read_ms write_ms
 	done

--- a/tests/block/020
+++ b/tests/block/020
@@ -20,20 +20,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="run null-blk on different schedulers with only one hardware tag"
 QUICK=1
 
 requires() {
-	_have_module null_blk && _have_fio
+	_have_null_blk && _have_fio
 }
 
 test() {
 	echo "Running ${TEST_NAME}"
 
-	modprobe -r null_blk
-	modprobe null_blk queue_mode=2 irqmode=2 completion_nsec=2000000 \
-		submit_queues=4 hw_queue_depth=1
+	if ! _init_null_blk queue_mode=2 irqmode=2 completion_nsec=2000000 \
+	     submit_queues=4 hw_queue_depth=1; then
+		return 1
+	fi
 
 	local scheds
 	# shellcheck disable=SC2207
@@ -48,8 +50,7 @@ test() {
 			--runtime=10
 	done
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 
 	echo "Test complete"
 }

--- a/tests/block/020
+++ b/tests/block/020
@@ -48,6 +48,7 @@ test() {
 			--runtime=10
 	done
 
+	udevadm settle
 	modprobe -r null_blk
 
 	echo "Test complete"

--- a/tests/block/021
+++ b/tests/block/021
@@ -20,19 +20,21 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="read/write nr_requests on null-blk with different schedulers"
 QUICK=1
 
 requires() {
-	_have_module null_blk
+	_have_null_blk
 }
 
 test() {
 	echo "Running ${TEST_NAME}"
 
-	modprobe -r null_blk
-	modprobe null_blk
+	if ! _init_null_blk; then
+		return 1
+	fi
 
 	local max_nr
 	local nr
@@ -49,8 +51,7 @@ test() {
 		done
 	done
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 
 	echo "Test complete"
 }

--- a/tests/block/021
+++ b/tests/block/021
@@ -49,6 +49,7 @@ test() {
 		done
 	done
 
+	udevadm settle
 	modprobe -r null_blk
 
 	echo "Test complete"

--- a/tests/block/022
+++ b/tests/block/022
@@ -51,6 +51,7 @@ test() {
 		wait
 	done
 
+	udevadm settle
 	modprobe -r null_blk
 
 	echo "Test complete"

--- a/tests/block/022
+++ b/tests/block/022
@@ -18,21 +18,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
+. common/null_blk
 
 DESCRIPTION="run null-blk with legacy blk path and timeout injection configured"
 
 requires() {
-	_have_module null-blk && _have_module_param null_blk timeout
+	_have_null_blk && _have_module_param null_blk timeout
 }
 
 test() {
 	echo "Running ${TEST_NAME}"
 
-	modprobe -r null_blk
-
 	# The format is "<interval>,<probability>,<space>,<times>". Here, we
 	# fail 50% of I/Os.
-	modprobe null_blk queue_mode=1 timeout='1,50,0,-1'
+	if ! _init_null_blk queue_mode=1 timeout='1,50,0,-1'; then
+		return 1
+	fi
 
 	local scheds
 	# shellcheck disable=SC2207
@@ -51,8 +52,7 @@ test() {
 		wait
 	done
 
-	udevadm settle
-	modprobe -r null_blk
+	_exit_null_blk
 
 	echo "Test complete"
 }


### PR DESCRIPTION
Hi,

I am not sure it happens only on my machines but I often have "modprobe: FATAL: Module null_blk is in use." error.
So I adds "udevadm settle" before unloading null_blk module.

Second and third pathes create and apply common helpers for using null_blk module.
They do not fix anything.