### PR TITLE
src/discontiguous-io: Do not shadow variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: c
+
+os:
+  - linux
+
+# The version of GNU make in the default image is too old. Hence select trusty.
+dist: trusty
+
+compiler:
+  - clang
+  - gcc
+
+env:
+  matrix:
+    - BUILD_ARCH="x86"
+    - BUILD_ARCH="x86_64"
+
+addons:
+  apt:
+    packages:
+      - gcc
+      - gcc-multilib
+      - make
+
+before_install:
+  - CFLAGS="-Werror"
+  - CXXFLAGS="-Werror"
+  - if [ "$BUILD_ARCH" == "x86" ]; then
+        CFLAGS="$CFLAGS -m32";
+        CXXFLAGS="$CXXFLAGS -m32";
+    fi
+
+script:
+  - make CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS"

--- a/common/multipath-over-rdma
+++ b/common/multipath-over-rdma
@@ -14,6 +14,14 @@ if [ $ramdisk_size -gt $max_ramdisk_size ]; then
 	ramdisk_size=$max_ramdisk_size
 fi
 
+have_legacy_dm() {
+	if ! _have_kernel_option DM_MQ_DEFAULT; then
+		SKIP_REASON="legacy device mapper support is missing"
+		echo "$SKIP_REASON" >/dev/null # For shellcheck
+		return 1
+	fi
+}
+
 get_ipv4_addr() {
 	ip -4 -o addr show dev "$1" |
 		sed -n 's/.*[[:blank:]]inet[[:blank:]]*\([^[:blank:]/]*\).*/\1/p'

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,8 +12,8 @@ CXX_TARGETS := \
 
 TARGETS := $(C_TARGETS) $(CXX_TARGETS)
 
-CFLAGS := -O2 -Wall
-CXXFLAGS := -O2 -std=c++11 -Wall -Wextra -Wno-sign-compare -Werror
+CFLAGS := -O2 -Wall -Wshadow
+CXXFLAGS := -O2 -std=c++11 -Wall -Wextra -Wshadow -Wno-sign-compare -Werror
 
 all: $(TARGETS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,8 +12,8 @@ CXX_TARGETS := \
 
 TARGETS := $(C_TARGETS) $(CXX_TARGETS)
 
-CFLAGS := -O2 -Wall -Wshadow
-CXXFLAGS := -O2 -std=c++11 -Wall -Wextra -Wshadow -Wno-sign-compare -Werror
+CFLAGS   += -O2 -Wall -Wshadow
+CXXFLAGS += -O2 -std=c++11 -Wall -Wextra -Wshadow -Wno-sign-compare -Werror
 
 all: $(TARGETS)
 

--- a/src/discontiguous-io.cpp
+++ b/src/discontiguous-io.cpp
@@ -306,17 +306,17 @@ int main(int argc, char **argv)
 					break;
 				}
 			}
-			ssize_t len = sg_write(fd, offs / block_size, iov);
-			if (len >= 0)
-				std::cout << "Wrote " << len << "/"
+			ssize_t written = sg_write(fd, offs / block_size, iov);
+			if (written >= 0)
+				std::cout << "Wrote " << written << "/"
 					  << iov.data_len()
 					  << " bytes of data.\n";
 		} else {
-			ssize_t len = sg_read(fd, offs / block_size, iov);
-			if (len >= 0) {
-				std::cerr << "Read " << len
+			ssize_t read = sg_read(fd, offs / block_size, iov);
+			if (read >= 0) {
+				std::cerr << "Read " << read
 					  << " bytes of data:\n";
-				iov.trunc(len);
+				iov.trunc(read);
 				iov.write(std::cout);
 			}
 		}

--- a/src/sg/syzkaller1.c
+++ b/src/sg/syzkaller1.c
@@ -402,7 +402,7 @@ void test()
 {
   memset(r, -1, sizeof(r));
   r[0] = execute_syscall(__NR_mmap, 0x20000000ul, 0x5000ul, 0x3ul,
-                         0x32ul, 0xfffffffffffffffful, 0x0ul, 0, 0, 0);
+                         0x32ul, -1, 0x0ul, 0, 0, 0);
   NONFAILING(memcpy((void*)0x20000000,
                     dev_sg, strlen(dev_sg)));
   r[2] = execute_syscall(__NR_syz_open_dev, 0x20000000ul, 0x0ul, 0x2ul,

--- a/tests/nvmeof-mp/004
+++ b/tests/nvmeof-mp/004
@@ -7,6 +7,10 @@
 DESCRIPTION="File I/O on top of multipath concurrently with logout and login (sq-on-mq)"
 TIMED=1
 
+requires() {
+	have_legacy_dm || return $?
+}
+
 test_disconnect_repeatedly() {
 	local dev fio_status m
 

--- a/tests/nvmeof-mp/013
+++ b/tests/nvmeof-mp/013
@@ -1,0 +1,32 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0+
+# Copyright 2018 Google LLC
+
+. tests/nvmeof-mp/rc
+
+DESCRIPTION="Disconnect and reconnect repeatedly"
+QUICK=1
+
+test_repeated_logins() {
+	local dev m n=32 rc
+
+	use_blk_mq y || return $?
+	for ((i = 0; i < n; i++)); do
+		if ! dev=$(get_bdev 0); then
+			rc=$?
+			echo "Executed $i out of $n iterations"
+			return $rc
+		fi
+		log_out
+		# Delay that get_bdev() hits a race condition between device
+		# node removal and creation.
+		sleep 1
+		log_in
+	done
+	return 0
+}
+
+test() {
+	trap 'trap "" EXIT; teardown' EXIT
+	setup && test_repeated_logins && echo Passed
+}

--- a/tests/nvmeof-mp/013.out
+++ b/tests/nvmeof-mp/013.out
@@ -1,0 +1,2 @@
+Configured NVMe target driver
+Passed

--- a/tests/srp/003
+++ b/tests/srp/003
@@ -7,6 +7,10 @@
 DESCRIPTION="File I/O on top of multipath concurrently with logout and login (sq)"
 TIMED=1
 
+requires() {
+	have_legacy_dm || return $?
+}
+
 test_disconnect_repeatedly() {
 	local dev fio_status m
 

--- a/tests/srp/004
+++ b/tests/srp/004
@@ -7,6 +7,10 @@
 DESCRIPTION="File I/O on top of multipath concurrently with logout and login (sq-on-mq)"
 TIMED=1
 
+requires() {
+	have_legacy_dm || return $?
+}
+
 test_disconnect_repeatedly() {
 	local dev fio_status m
 

--- a/tests/srp/012
+++ b/tests/srp/012
@@ -15,6 +15,7 @@ test_io_schedulers() {
 		modprobe "$(basename "$m")" >&/dev/null
 	done
 	for mq in y n; do
+		[ $mq = n ] && ! have_legacy_dm && continue
 		use_blk_mq ${mq} ${mq} || return $?
 		dev=$(get_bdev 0) || return $?
 		for sched in noop deadline bfq cfq; do


### PR DESCRIPTION
Avoid using variables in an inner scope with the same name as variables in
an outer scope. Enable the -Wshadow compiler flag for C and C++ source
files such that in the future the compiler will complain about shadowing.

Signed-off-by: Bart Van Assche <bvanassche@acm.org>