### PR TITLE
scsi/006: cache_type change may be not supported by device

### DIFF
--- a/tests/scsi/006
+++ b/tests/scsi/006
@@ -27,13 +27,31 @@ test_device() {
 	)
 	local cache_type
 	local original_cache_type
+	local not_supported
+	local new_cache_type
 
 	original_cache_type="$(cat "${TEST_DEV_SYSFS}"/device/scsi_disk/*/cache_type)"
 	for cache_type in "${cache_types[@]}"; do
-		echo "$cache_type" > "${TEST_DEV_SYSFS}"/device/scsi_disk/*/cache_type
-		cat "${TEST_DEV_SYSFS}"/device/scsi_disk/*/cache_type
+		(
+			echo "$cache_type" > "${TEST_DEV_SYSFS}"/device/scsi_disk/*/cache_type
+		) |& awk 'inval=/Invalid argument$/ { ret=1 } !inval { print $0 } END { exit ret }'
+		not_supported=$?
+
+		if [ $not_supported -eq 0 ]; then
+			new_cache_type="$(cat "${TEST_DEV_SYSFS}"/device/scsi_disk/*/cache_type)"
+			if [ "${new_cache_type}" = "${cache_type}" ]; then
+				echo "${cache_type}: success or not supported"
+			else
+				echo "${cache_type}: change failed"
+			fi
+		else
+			echo "${cache_type}: success or not supported"
+		fi
 	done
-	echo "$original_cache_type" > "${TEST_DEV_SYSFS}"/device/scsi_disk/*/cache_type
+
+	(
+		echo "$original_cache_type" > "${TEST_DEV_SYSFS}"/device/scsi_disk/*/cache_type
+	) |& grep -v "Invalid argument$"
 
 	echo "Test complete"
 }

--- a/tests/scsi/006.out
+++ b/tests/scsi/006.out
@@ -1,6 +1,6 @@
 Running scsi/006
-write through
-none
-write back
-write back, no read (daft)
+write through: success or not supported
+none: success or not supported
+write back: success or not supported
+write back, no read (daft): success or not supported
 Test complete


### PR DESCRIPTION
There are at least two SCSI/SAS controllers that do not support
changing of cache_type:

	HP Smart Array P410i (103c:323a, hpsa)
	Dell PERC H200 (1000:0072, mpt3sas)

When trying to change cache_type, write always fails:

	# echo "none" >cache_type
	bash: echo: write error: Invalid argument

And following appears in dmesg:

	[13007.865745] sd 1:0:1:0: [sda] Sense Key : Illegal Request [current]
	[13007.865753] sd 1:0:1:0: [sda] Add. Sense: Invalid field in parameter list

This happens even when trying to write value that is equal to current.