### PR TITLE
Better fix for osandov/blktests#28

### DIFF
--- a/common/fio
+++ b/common/fio
@@ -156,7 +156,7 @@ _run_fio() {
 		args+=("--runtime=$TIMEOUT")
 	fi
 
-	if ! fio "${args[@]}" "$@"; then
+	if ! BLKTESTS_MARKER=1 fio "${args[@]}" "$@"; then
 		echo "fio exited with status $?"
 		cat "$TMPDIR"/fio_perf
 	fi
@@ -172,6 +172,14 @@ _run_fio_rand_io() {
 _run_fio_verify_io() {
 	_run_fio --name=verify --rw=randwrite --direct=1 --ioengine=libaio --bs=4k \
 		--norandommap --iodepth=16 --verify=crc32c "$@"
+}
+
+# Succeeds if block device $1 is opened by fio.
+_is_fio_running() {
+	for p in $( _get_bdev_users "$1" ); do
+		grep -qz "^BLKTESTS_MARKER=1$" "/proc/$p/environ" 2>/dev/null && return 0
+	done
+	return 1
 }
 
 _fio_perf_report() {

--- a/common/multipath-over-rdma
+++ b/common/multipath-over-rdma
@@ -122,12 +122,9 @@ sleep_until() {
 # Kill all processes that have opened block device $1.
 stop_bdev_users() {
 	[ -n "$1" ] || return $?
-	lsof -F p "$1" 2>/dev/null | while read -r line; do
-		p="${line#p}"
-		if [ "$p" != "$line" ]; then
-			echo -n " (pid $p)" >>"$FULL"
-			kill -9 "$p"
-		fi
+	for p in $( _get_bdev_users "$1" ); do
+		echo -n " (pid $p)" >>"$FULL"
+		kill -9 "$p"
 	done
 }
 

--- a/common/rc
+++ b/common/rc
@@ -213,3 +213,11 @@ _test_dev_in_hotplug_slot() {
 _filter_xfs_io_error() {
 	sed -e 's/^\(.*\)64\(: .*$\)/\1\2/'
 }
+
+# Find process IDs of all processes that have opened block device $1.
+_get_bdev_users() {
+	lsof -F p "$1" 2>/dev/null | while read -r line; do
+		p="${line#p}"
+		[ "$p" != "$line" ] && echo "$p"
+	done
+}

--- a/tests/block/008
+++ b/tests/block/008
@@ -41,6 +41,13 @@ test_device() {
 		fi
 	done
 
+	# Ensure that fio has started doing actual IO.
+	while kill -0 $! 2> /dev/null; do
+		_is_fio_running "$TEST_DEV" && break
+		sleep .2
+	done
+	kill -0 $! 2> /dev/null || echo "failure: fio terminated unexpectedly"
+
 	# while job is running, hotplug CPUs
 	while sleep .2; kill -0 $! 2> /dev/null; do
 		if (( offlining && ${#offline_cpus[@]} == max_offline )); then


### PR DESCRIPTION
I'm constantly hitting this problem:

	block/008 => sdb (do IO while hotplugging CPUs)              [failed]
	    runtime    ...  258.910s
	    --- tests/block/008.out     2018-12-06 07:52:28.971820224 +0500
	    +++ /root/blktests/results/sdb/block/008.out.bad    2018-12-09 19:25:08.973348308 +0500
	    @@ -1,2 +1,4 @@
	     Running block/008
	    +clock setaffinity failed: Invalid argument
	    +_fio_perf: too many terse lines
	     Test complete

It seems that 0.2 second sleep is not enough because my system is too slow.

Instead of adding more sleep, this patch implements proper (I hope so)
logic that waits until fio opens the test device.

Signed-off-by: Ivan Mironov <mironov.ivan@gmail.com>