### PR TITLE
Add support for older bash versions

### DIFF
--- a/check
+++ b/check
@@ -4,6 +4,8 @@
 
 shopt -s extglob
 
+. common/realpath
+
 _warning() {
 	echo "$0: $*" >&2
 }

--- a/check
+++ b/check
@@ -24,7 +24,7 @@ _found_test() {
 		return 1
 	fi
 
-	if [[ -z $DESCRIPTION ]]; then
+	if [ -z "${DESCRIPTION:-}" ]; then
 		_warning "${test_name} does not define DESCRIPTION"
 		return 1
 	fi
@@ -50,13 +50,13 @@ _found_test() {
 	fi
 
 	if (( ! explicit )); then
-		if [[ $DEVICE_ONLY -ne 0 ]] && ! declare -fF test_device >/dev/null; then
+		if [ "$DEVICE_ONLY" -ne 0 ] && ! declare -fF test_device >/dev/null; then
 			return
 		fi
 		if (( QUICK_RUN && !QUICK && !TIMED )); then
 			return
 		fi
-		if [[ -n ${EXCLUDE["$test_name"]} ]]; then
+		if [ -n "${EXCLUDE["$test_name"]}" ]; then
 			return
 		fi
 	fi
@@ -71,7 +71,7 @@ _found_group() {
 	local test_path
 
 	if (( ! explicit )); then
-		if [[ -n ${EXCLUDE["$group"]} ]]; then
+		if [ -n "${EXCLUDE["$group"]}" ]; then
 			return
 		fi
 	fi
@@ -82,11 +82,11 @@ _found_group() {
 }
 
 _find_tests() {
-	if [[ $# -eq 0 ]]; then
+	if [ $# -eq 0 ]; then
 		# No filters given, run all tests except for the meta group.
 		local group_path
 		while IFS= read -r -d '' group_path; do
-			if [[ $group_path != tests/meta ]]; then
+			if [ "$group_path" != tests/meta ]; then
 				_found_group "${group_path#tests/}" 0
 			fi
 		done < <(find tests -mindepth 2 -type f -name rc -printf '%h\0')
@@ -96,10 +96,14 @@ _find_tests() {
 			# A filter is bad if it:
 			#     - Is an absolute path
 			#     - Is a relative path containing ".."
-			if [[ $filter =~ ^/|(^|/)\.\.(/|$) ]]; then
-				_warning "bad filter ${filter}"
-				continue
-			fi
+			case $filter in
+				/*|../*|*/../*|*/..)
+					_warning "bad filter ${filter}"
+					continue;;
+				"")
+					_warning "bad filter ${filter}"
+					continue;;
+			esac
 			# Remove leading and internal "." components.
 			filter="${filter##+(./)}"
 			filter="${filter//\/+(.\/)/\/}"
@@ -108,9 +112,9 @@ _find_tests() {
 			# Remove leading "tests/"
 			filter="${filter#tests/}"
 
-			if [[ -d tests/$filter ]]; then
+			if [ -d "tests/$filter" ]; then
 				_found_group "$filter" 1
-			elif [[ -f tests/$filter ]]; then
+			elif [ -f "tests/$filter" ]; then
 				_found_test "$filter" 1
 			else
 				_warning "no group or test named ${filter}"
@@ -123,7 +127,7 @@ _check_dmesg() {
 	local dmesg_marker="$1"
 	local seqres="${RESULTS_DIR}/${TEST_NAME}"
 
-	if [[ $CHECK_DMESG -eq 0 ]]; then
+	if [ "$CHECK_DMESG" -eq 0 ]; then
 		return 0
 	fi
 
@@ -139,7 +143,7 @@ _check_dmesg() {
 	     -e "general protection fault:" \
 	     "${seqres}.dmesg"
 	# shellcheck disable=SC2181
-	if [[ $? -eq 0 ]]; then
+	if [ $? -eq 0 ]; then
 		return 1
 	else
 		rm -f "${seqres}.dmesg"
@@ -161,7 +165,7 @@ _read_last_test_run() {
 	LAST_TEST_RUN["exit_status"]=""
 	LAST_TEST_RUN["runtime"]=""
 
-	if [[ ! -e $seqres ]]; then
+	if [ ! -e "$seqres" ]; then
 		return
 	fi
 
@@ -183,18 +187,18 @@ _output_status() {
 	local test="$1"
 	local status="$2"
 
-	if [[ -v DESCRIPTION ]]; then
+	if [ -n "${DESCRIPTION:-}" ]; then
 		printf '%-60s' "$test ($DESCRIPTION)"
 	else
 		printf '%-60s' "$test"
 	fi
-	if [[ -z $status ]]; then
+	if [ -z "$status" ]; then
 		echo
 		return
 	fi
 
 	echo -n " ["
-	if [[ -t 1 ]]; then
+	if [ -t 1 ]; then
 		case "$status" in
 		passed)
 			tput setaf 2
@@ -208,7 +212,7 @@ _output_status() {
 		esac
 	fi
 	echo -n "$status"
-	if [[ -t 1 ]]; then
+	if [ -t 1 ]; then
 		tput sgr0
 	fi
 	echo "]"
@@ -220,7 +224,7 @@ _output_notrun() {
 }
 
 _output_last_test_run() {
-	if [[ -v TEST_DEV ]]; then
+	if [ -n "${TEST_DEV:-}" ]; then
 		_output_status "$TEST_NAME => $(basename "$TEST_DEV")" ""
 	else
 		_output_status "$TEST_NAME" ""
@@ -229,9 +233,10 @@ _output_last_test_run() {
 	(
 	local key value
 	while IFS= read -r key; do
-		if [[ $key =~ ^date|status|reason|exit_status$ ]]; then
-			continue
-		fi
+		case "$key" in
+			date|status|reason|exit_status)
+				continue;;
+		esac
 		value="${LAST_TEST_RUN["$key"]}"
 		printf '    %s\t%s\t...\n' "${key}" "${value}"
 	done < <(printf '%s\n' "${!LAST_TEST_RUN[@]}" | sort)
@@ -239,13 +244,13 @@ _output_last_test_run() {
 }
 
 _output_test_run() {
-	if [[ -t 1 ]]; then
+	if [ -t 1 ]; then
 		# -4 for date, status, reason, and exit_status, which we don't
 		# output, +1 for the test name.
 		tput cuu $((${#LAST_TEST_RUN[@]} - 3))
 	fi
 
-	if [[ -v TEST_DEV ]]; then
+	if [ -n "${TEST_DEV:-}" ]; then
 		_output_status "$TEST_NAME => $(basename "$TEST_DEV")" "${TEST_RUN["status"]}ed"
 	else
 		_output_status "$TEST_NAME" "${TEST_RUN["status"]}ed"
@@ -254,9 +259,10 @@ _output_test_run() {
 	(
 	local key last_value value
 	while IFS= read -r key; do
-		if [[ $key =~ ^date|status|reason|exit_status$ ]]; then
-			continue
-		fi
+		case "$key" in
+			date|status|reason|exit_status)
+				continue;;
+		esac
 		last_value="${LAST_TEST_RUN["$key"]}"
 		value="${TEST_RUN["$key"]}"
 		printf '    %s\t%s\t...\t%s\n' "$key" "$last_value" "$value"
@@ -265,7 +271,8 @@ _output_test_run() {
 	while IFS= read -r key; do
 		# [[ -v array[key] ]] was added in Bash 4.3. Do it this ugly
 		# way to support older versions.
-		if [[ -n ${LAST_TEST_RUN["$key"]} || ${LAST_TEST_RUN["$key"]-unset} != unset ]]; then
+		if [ -n "${LAST_TEST_RUN["$key"]}" ] ||
+			   [ "${LAST_TEST_RUN["$key"]-unset}" != unset ]; then
 			continue
 		fi
 		value="${TEST_RUN["$key"]}"
@@ -275,7 +282,7 @@ _output_test_run() {
 }
 
 _cleanup() {
-	if [[ -v TMPDIR ]]; then
+	if [ -n "${TMPDIR:-}" ]; then
 		rm -rf "$TMPDIR"
 		unset TMPDIR
 	fi
@@ -287,7 +294,7 @@ _cleanup() {
 		unset TEST_DEV_QUEUE_SAVED["$key"]
 	done
 
-	if [[ -v RESTORE_CPUS_ONLINE ]]; then
+	if [ -n "${RESTORE_CPUS_ONLINE:-}" ]; then
 		local cpu
 		for cpu in "${!CPUS_ONLINE_SAVED[@]}"; do
 			echo "${CPUS_ONLINE_SAVED["$cpu"]}" >"/sys/devices/system/cpu/cpu$cpu/online"
@@ -312,7 +319,7 @@ _call_test() {
 	# Remove leftovers from last time.
 	rm -f "${seqres}" "${seqres}."*
 
-	if [[ -w /dev/kmsg ]]; then
+	if [ -w /dev/kmsg ]; then
 		local dmesg_marker="run blktests $TEST_NAME at ${TEST_RUN["date"]}"
 		echo "$dmesg_marker" >> /dev/kmsg
 	else
@@ -340,7 +347,7 @@ _call_test() {
 		mv "${seqres}.out" "${seqres}.out.bad"
 		TEST_RUN["status"]=fail
 		TEST_RUN["reason"]=output
-	elif [[ ${TEST_RUN["exit_status"]} -ne 0 ]]; then
+	elif [ ${TEST_RUN["exit_status"]} -ne 0 ]; then
 		TEST_RUN["status"]=fail
 		TEST_RUN["reason"]="exit"
 	elif ! _check_dmesg "$dmesg_marker"; then
@@ -354,7 +361,7 @@ _call_test() {
 	_write_test_run
 	_output_test_run
 
-	if [[ ${TEST_RUN["status"]} = pass ]]; then
+	if [ ${TEST_RUN["status"]} = pass ]; then
 		return 0
 	else
 		case "${TEST_RUN["reason"]}" in
@@ -406,7 +413,7 @@ _run_test() {
 		RESULTS_DIR="$OUTPUT/nodev"
 		_call_test test
 	else
-		if [[ ${#TEST_DEVS[@]} -eq 0 ]]; then
+		if [ ${#TEST_DEVS[@]} -eq 0 ]; then
 			return 0
 		fi
 
@@ -476,12 +483,13 @@ _find_sysfs_dir() {
 
 	local block_dir part_dir
 	for block_dir in /sys/block/*; do
-		if [[ $(cat "${block_dir}/dev") = "$dev" ]]; then
+		if [ "$(cat "${block_dir}/dev")" = "$dev" ]; then
 			echo "$block_dir"
 			return
 		fi
 		for part_dir in "$block_dir"/*; do
-			if [[ -r ${part_dir}/dev && $(cat "${part_dir}/dev") = "$dev" ]]; then
+			if [ -r "${part_dir}/dev" ] &&
+				   [ "$(cat "${part_dir}/dev")" = "$dev" ]; then
 				echo "$block_dir"
 				return
 			fi
@@ -498,9 +506,9 @@ _check() {
 
 	local test_dev
 	for test_dev in "${TEST_DEVS[@]}"; do
-		if [[ ! -e $test_dev ]]; then
+		if [ ! -e "$test_dev" ]; then
 			_error "${test_dev} does not exist"
-		elif [[ ! -b $test_dev ]]; then
+		elif [ ! -b "$test_dev" ]; then
 			_error "${test_dev} is not a block device"
 		fi
 
@@ -516,9 +524,9 @@ _check() {
 	local ret=0
 	while IFS= read -r -d '' test_name; do
 		group="${test_name%/*}"
-		if [[ $group != "$prev_group" ]]; then
+		if [ "$group" != "$prev_group" ]; then
 			prev_group="$group"
-			if [[ ${#tests[@]} -gt 0 ]]; then
+			if [ ${#tests[@]} -gt 0 ]; then
 				if ! ( _run_group "${tests[@]}" ); then
 					ret=1
 				fi
@@ -528,7 +536,7 @@ _check() {
 		tests+=("$test_name")
 	done < <(_find_tests "$@" | sort -zu)
 
-	if [[ ${#tests[@]} -gt 0 ]]; then
+	if [ ${#tests[@]} -gt 0 ]; then
 		if ! ( _run_group "${tests[@]}" ); then
 			ret=1
 		fi
@@ -581,7 +589,7 @@ unset TEMP
 
 LOGGER_PROG="$(type -P logger)" || LOGGER_PROG=true
 
-if [[ -r config ]]; then
+if [ -r config ]; then
 	# shellcheck disable=SC1091
 	. config
 fi
@@ -590,18 +598,19 @@ fi
 : "${DEVICE_ONLY:=0}"
 : "${QUICK_RUN:=0}"
 : "${OUTPUT:=results}"
-if [[ -v EXCLUDE ]] && ! declare -p EXCLUDE | grep -q '^declare -a'; then
+if [ -n "${EXCLUDE:-}" ] && ! declare -p EXCLUDE | grep -q '^declare -a'; then
 	# If EXCLUDE was not defined as an array, convert it to one.
 	# shellcheck disable=SC2190,SC2206
 	EXCLUDE=($EXCLUDE)
-elif [[ ! -v EXCLUDE ]]; then
+elif [ -z "${EXCLUDE:-}" ]; then
 	EXCLUDE=()
 fi
-if [[ -v TEST_DEVS ]] && ! declare -p TEST_DEVS | grep -q '^declare -a'; then
+if [ -n "${TEST_DEVS:-}" ] &&
+	   ! declare -p TEST_DEVS | grep -q '^declare -a'; then
 	# If TEST_DEVS was not defined as an array, convert it to one.
 	# shellcheck disable=SC2206
 	TEST_DEVS=($TEST_DEVS)
-elif [[ ! -v TEST_DEVS ]]; then
+elif [ -z "$TEST_DEVS" ]; then
 	TEST_DEVS=()
 fi
 
@@ -640,11 +649,11 @@ while true; do
 	esac
 done
 
-if [[ $QUICK_RUN -ne 0 && ! -v TIMEOUT ]]; then
+if [ $QUICK_RUN -ne 0 ] && [ -z "$TIMEOUT" ]; then
 	_error "QUICK_RUN specified without TIMEOUT"
 fi
 
-if [[ $DEVICE_ONLY -ne 0 && ${#TEST_DEVS[@]} -eq 0 ]]; then
+if [ $DEVICE_ONLY -ne 0 ] && [ ${#TEST_DEVS[@]} -eq 0 ]; then
 	_error "DEVICE_ONLY specified without TEST_DEVS"
 fi
 

--- a/common/cpuhotplug
+++ b/common/cpuhotplug
@@ -15,7 +15,7 @@ _have_cpu_hotplug() {
 	local cpu_dir cpu
 	for cpu_dir in /sys/devices/system/cpu/cpu+([0-9]); do
 		ALL_CPUS+=("$cpu")
-		if [[ -w ${cpu_dir}/online ]]; then
+		if [ -w "${cpu_dir}/online" ]; then
 			cpu="${cpu_dir#/sys/devices/system/cpu/cpu}"
 			HOTPLUGGABLE_CPUS+=("$cpu")
 			# shellcheck disable=SC2034
@@ -23,7 +23,8 @@ _have_cpu_hotplug() {
 		fi
 	done
 
-	if [[ ${#ALL_CPUS[@]} -eq 1 || ${#HOTPLUGGABLE_CPUS[@]} -eq 0 ]]; then
+	if [ "${#ALL_CPUS[@]}" -eq 1 ] ||
+		   [ "${#HOTPLUGGABLE_CPUS[@]}" -eq 0 ]; then
 		SKIP_REASON="CPU hotplugging is not supported"
 		return 1
 	fi

--- a/common/fio
+++ b/common/fio
@@ -152,7 +152,7 @@ _fio_perf() {
 _run_fio() {
 	local args=("--output=$TMPDIR/fio_perf" "--output-format=terse" "--terse-version=4" "--group_reporting=1")
 
-	if [[ -v TIMEOUT ]]; then
+	if [ -n "$TIMEOUT" ]; then
 		args+=("--runtime=$TIMEOUT")
 	fi
 
@@ -176,7 +176,7 @@ _run_fio_verify_io() {
 
 _fio_perf_report() {
 	# If there is more than one group, we don't know what to report.
-	if [[ $(wc -l < "$TMPDIR/fio_perf") -gt 1 ]]; then
+	if [ "$(wc -l < "$TMPDIR/fio_perf")" -gt 1 ]; then
 		echo "_fio_perf: too many terse lines" >&2
 		return
 	fi
@@ -184,7 +184,7 @@ _fio_perf_report() {
 	local name field value
 	for name in "${FIO_PERF_FIELDS[@]}"; do
 		field="${FIO_TERSE_FIELDS["$name"]}"
-		if [[ -z $field ]]; then
+		if [ -z "$field" ]; then
 			echo "_fio_perf: unknown fio terse field '$name'" >&2
 			continue
 		fi

--- a/common/multipath-over-rdma
+++ b/common/multipath-over-rdma
@@ -5,6 +5,7 @@
 # Functions and global variables used by both the srp and nvmeof-mp tests.
 
 . common/shellcheck
+. common/realpath
 
 debug=
 filesystem_type=ext4

--- a/common/multipath-over-rdma
+++ b/common/multipath-over-rdma
@@ -352,7 +352,7 @@ get_bdev_n() {
 # Full path of mountpoint $1. fio will be run on top of the filesystem mounted
 # at the returned mountpoint.
 function mountpoint() {
-	if [ -z "$TMPDIR" ]; then
+	if [ -z "${TMPDIR:-}" ]; then
 		echo "Error: \$TMPDIR has not been set." 1>&2
 		exit 1
 	fi

--- a/common/rc
+++ b/common/rc
@@ -84,8 +84,20 @@ _have_blktrace() {
 	_have_program blktrace
 }
 
+# $1: filesystem type; $2: mountpoint
+_findmnt() {
+	while read -r fs_spec mountpoint fstype rest; do
+		if [ "$1" = "$fstype" ] &&
+			   [ "$2" = "$mountpoint" ]; then
+			return 0
+		fi
+		echo "$fs_spec" >/dev/null # to suppress a shellcheck warning
+	done < /proc/self/mounts
+	return 1
+}
+
 _have_configfs() {
-	if ! findmnt -t configfs /sys/kernel/config >/dev/null; then
+	if ! _findmnt configfs /sys/kernel/config; then
 		SKIP_REASON="configfs is not mounted at /sys/kernel/config"
 		return 1
 	fi
@@ -111,7 +123,7 @@ _have_kernel_option() {
 
 _have_tracefs() {
 	stat /sys/kernel/debug/tracing/trace > /dev/null 2>&1
-	if ! findmnt -t tracefs /sys/kernel/debug/tracing >/dev/null; then
+	if ! _findmnt tracefs /sys/kernel/debug/tracing; then
 		SKIP_REASON="tracefs is not mounted at /sys/kernel/debug/tracing"
 		return 1
 	fi

--- a/common/rc
+++ b/common/rc
@@ -14,13 +14,13 @@ shopt -s extglob
 # for TIMEOUT / number of subtests.
 _divide_timeout() {
 	local num_tests="$1"
-	if [[ -v TIMEOUT ]]; then
+	if [ -n "$TIMEOUT" ]; then
 		((TIMEOUT = (TIMEOUT + num_tests - 1) / num_tests))
 	fi
 }
 
 _have_root() {
-	if [[ $EUID -ne 0 ]]; then
+	if [ $EUID -ne 0 ]; then
 		SKIP_REASON="not running as root"
 		return 1
 	fi
@@ -36,10 +36,10 @@ _have_modules() {
 			missing+=("$module")
 		fi
 	done
-	if [[ ${#missing} -gt 1 ]]; then
+	if [ ${#missing} -gt 1 ]; then
 		SKIP_REASON="the following modules are not available: ${missing[*]}"
 		return 1
-	elif [[ ${#missing} -eq 1 ]]; then
+	elif [ ${#missing} -eq 1 ]; then
 		SKIP_REASON="${missing[0]} module is not available"
 		return 1
 	fi
@@ -63,7 +63,7 @@ _have_program() {
 }
 
 _have_src_program() {
-	if [[ ! -x "$SRCDIR/$1" ]]; then
+	if [ ! -x "$SRCDIR/$1" ]; then
 		SKIP_REASON="$1 was not built; run \`make\`"
 		return 1
 	fi
@@ -77,7 +77,7 @@ _have_loop() {
 _have_blktrace() {
 	# CONFIG_BLK_DEV_IO_TRACE might still be disabled, but this is easier
 	# to check. We can fix it if someone complains.
-	if [[ ! -d /sys/kernel/debug/block ]]; then
+	if [ ! -d /sys/kernel/debug/block ]; then
 		SKIP_REASON="CONFIG_DEBUG_FS is not enabled"
 		return 1
 	fi
@@ -121,7 +121,7 @@ _have_tracefs() {
 _have_tracepoint() {
 	local event=$1
 
-	if [[ ! -d /sys/kernel/debug/tracing/events/${event} ]]; then
+	if [ ! -d "/sys/kernel/debug/tracing/events/${event}" ]; then
 		SKIP_REASON="tracepoint ${event} does not exist"
 		return 1
 	fi
@@ -129,7 +129,7 @@ _have_tracepoint() {
 }
 
 _test_dev_can_discard() {
-	if [[ $(cat "${TEST_DEV_SYSFS}/queue/discard_max_bytes") -eq 0 ]]; then
+	if [ "$(cat "${TEST_DEV_SYSFS}/queue/discard_max_bytes")" -eq 0 ]; then
 		SKIP_REASON="$TEST_DEV does not support discard"
 		return 1
 	fi
@@ -137,7 +137,7 @@ _test_dev_can_discard() {
 }
 
 _test_dev_is_rotational() {
-	if [[ $(cat "${TEST_DEV_SYSFS}/queue/rotational") -eq 0 ]]; then
+	if [ "$(cat "${TEST_DEV_SYSFS}/queue/rotational")" -eq 0 ]; then
 		SKIP_REASON="$TEST_DEV is not rotational"
 		return 1
 	fi
@@ -145,7 +145,7 @@ _test_dev_is_rotational() {
 }
 
 _test_dev_queue_get() {
-	if [[ $1 = scheduler ]]; then
+	if [ "$1" = scheduler ]; then
 		sed -e 's/.*\[//' -e 's/\].*//' "${TEST_DEV_SYSFS}/queue/scheduler"
 	else
 		cat "${TEST_DEV_SYSFS}/queue/$1"
@@ -153,9 +153,9 @@ _test_dev_queue_get() {
 }
 
 _test_dev_queue_set() {
-	# For bash >=4.3 we'd write if [[ ! -v TEST_DEV_QUEUE_SAVED["$1"] ]].
-	if [[ -z ${TEST_DEV_QUEUE_SAVED["$1"]} &&
-	      ${TEST_DEV_QUEUE_SAVED["$1"]-unset} == unset ]]; then
+	# For bash >=4.3 we'd write if [ ! -v TEST_DEV_QUEUE_SAVED["$1"] ].
+	if [ -z "${TEST_DEV_QUEUE_SAVED["$1"]}" ] &&
+	      [ "${TEST_DEV_QUEUE_SAVED["$1"]-unset}" == unset ]; then
 		TEST_DEV_QUEUE_SAVED["$1"]="$(_test_dev_queue_get "$1")"
 	fi
 	echo "$2" >"${TEST_DEV_SYSFS}/queue/$1"
@@ -200,7 +200,7 @@ _test_dev_in_hotplug_slot() {
 
 	local slt_cap
 	slt_cap="$(setpci -s "${parent}" CAP_EXP+14.w)"
-	if [[ $((0x${slt_cap} & 0x20)) -eq 0 ]]; then
+	if [ $((0x${slt_cap} & 0x20)) -eq 0 ]; then
 		SKIP_REASON="$TEST_DEV is not in a hot pluggable slot"
 		return 1
 	fi

--- a/common/realpath
+++ b/common/realpath
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0+
+# Copyright 2018 Google, Inc.
+
+# Execute the realpath binary if it is available. If it is not available,
+# use readlink.
+realpath() {
+	local p q
+
+	p=$(type -p realpath 2>/dev/null)
+	if [ -n "$p" ]; then
+		$p "$@"
+	else
+		q="$1"
+		if [ "${p:0:1}" != / ]; then
+			q=$PWD/$q
+		fi
+		readlink -f "$q"
+	fi
+}

--- a/common/scsi_debug
+++ b/common/scsi_debug
@@ -20,7 +20,7 @@ _init_scsi_debug() {
 	SCSI_DEBUG_TARGETS=()
 	SCSI_DEBUG_DEVICES=()
 	for host_sysfs in /sys/class/scsi_host/*; do
-		if [[ "$(cat "${host_sysfs}/proc_name")" = scsi_debug ]]; then
+		if [ "$(cat "${host_sysfs}/proc_name")" = scsi_debug ]; then
 			host="${host_sysfs#/sys/class/scsi_host/host}"
 			SCSI_DEBUG_HOSTS+=("$host")
 			for target_sysfs in /sys/class/scsi_device/"$host":*; do
@@ -31,13 +31,13 @@ _init_scsi_debug() {
 		fi
 	done
 
-	if [[ ${#SCSI_DEBUG_HOSTS[@]} -eq 0 ]]; then
+	if [ ${#SCSI_DEBUG_HOSTS[@]} -eq 0 ]; then
 		echo "Could not find scsi_debug hosts" >&2
 		_exit_scsi_debug
 		return 1
 	fi
 
-	if [[ ${#SCSI_DEBUG_TARGETS[@]} -eq 0 ]]; then
+	if [ ${#SCSI_DEBUG_TARGETS[@]} -eq 0 ]; then
 		echo "Could not find scsi_debug targets" >&2
 		_exit_scsi_debug
 		return 1

--- a/new
+++ b/new
@@ -11,26 +11,28 @@ _error() {
 }
 
 prompt_yes_no() {
-	if [[ $2 =~ ^[Yy] ]]; then
-		local default=0
-		local prompt="$1 [Y/n] "
-	else
-		local default=1
-		local prompt="$1 [y/N] "
-	fi
+	local default
+	local prompt
+
+	case "$2" in
+		Y*|y*)
+			default=0
+			prompt="$1 [Y/n] ";;
+		*)
+			default=1
+			prompt="$1 [y/N] ";;
+	esac
 
 	local yn
 	read -r -n 1 -p "${prompt}" yn
-	if [[ -n "${yn}" ]]; then
+	if [ -n "${yn}" ]; then
 		echo
 	fi
-	if [[ "${yn}" =~ ^[Yy] ]]; then
-		return 0
-	elif [[ "${yn}" =~ ^[Nn] ]]; then
-		return 1
-	else
-		return $default
-	fi
+	case "${yn}" in
+		Y|y) return 0;;
+		N|n) return 1;;
+		*) return $default;;
+	esac
 }
 
 echo "Available test groups:"
@@ -38,15 +40,15 @@ find tests -mindepth 1 -maxdepth 1 -type d -not -name meta -printf '    %P\n' | 
 
 read -r -p "Category for new test (pick one of the above or create a new one): " group
 
-if [[ -z $group ]]; then
+if [ -z "$group" ]; then
 	exit 1
 fi
 
-if [[ $group =~ [[:space:]/] ]]; then
+if echo "$group" | grep -q '[[:space:]/]'; then
 	_error 'group name must not contain whitespace or "/"'
 fi
 
-if [[ ! -e tests/${group} ]]; then
+if [ ! -e "tests/${group}" ]; then
 	if ! prompt_yes_no "Category does not exist; create it?"; then
 		exit 1
 	fi
@@ -98,7 +100,7 @@ fi
 for ((i = 1; ; i++)); do
 	seq="$(printf "%03d" $i)"
 	test_name="${group}/${seq}"
-	if [[ ! -e tests/${test_name} ]]; then
+	if [ ! -e "tests/${test_name}" ]; then
 		break
 	fi
 done
@@ -221,9 +223,8 @@ test() {
 # - Functions defined by the testing framework or group scripts, including
 #   helpers, have a leading underscore. E.g., _have_scsi_debug. Functions local
 #   to the test should not have a leading underscore.
-# - Use the bash [[ ]] form of tests instead of [ ].
-# - Always quote variable expansions unless the variable is a number or inside of
-#   a [[ ]] test.
+# - Use the bash [ ] form of tests instead of [[ ]].
+# - Always quote variable expansions unless the variable is a number.
 # - Use the \$() form of command substitution instead of backticks.
 # - Use bash for loops instead of seq. E.g., for ((i = 0; i < 10; i++)), not
 #   for i in \$(seq 0 9).

--- a/tests/block/001
+++ b/tests/block/001
@@ -27,7 +27,7 @@ stress_scsi_debug() {
 		host="${target%%:*}"
 		scan="${target#*:}"
 		scan="${scan//:/ }"
-		while [[ ! -e "$TMPDIR/stop" ]]; do
+		while [ ! -e "$TMPDIR/stop" ]; do
 			echo "${scan}" > "/sys/class/scsi_host/host${host}/scan"
 			echo 1 > "/sys/class/scsi_device/${target}/device/delete"
 		done

--- a/tests/block/002
+++ b/tests/block/002
@@ -25,11 +25,11 @@ test() {
 	blktrace -D "$TMP_DIR" "/dev/${SCSI_DEBUG_DEVICES[0]}" >"$FULL" 2>&1 &
 	sleep 0.5
 	echo 1 > "/sys/block/${SCSI_DEBUG_DEVICES[0]}/device/delete"
-	if [[ ! -d /sys/kernel/debug/block/${SCSI_DEBUG_DEVICES[0]} ]]; then
+	if [ ! -d "/sys/kernel/debug/block/${SCSI_DEBUG_DEVICES[0]}" ]; then
 		echo "debugfs directory deleted with blktrace active"
 	fi
 	{ kill $!; wait; } >/dev/null 2>/dev/null
-	if [[ -d /sys/kernel/debug/block/${SCSI_DEBUG_DEVICES[0]} ]]; then
+	if [ -d "/sys/kernel/debug/block/${SCSI_DEBUG_DEVICES[0]}" ]; then
 		echo "debugfs directory leaked"
 	fi
 

--- a/tests/block/008
+++ b/tests/block/008
@@ -30,7 +30,7 @@ test_device() {
 	local offline_cpus=()
 	local offlining=1
 	local max_offline=${#HOTPLUGGABLE_CPUS[@]}
-	if [[ ${#HOTPLUGGABLE_CPUS[@]} -eq ${#ALL_CPUS[@]} ]]; then
+	if [ ${#HOTPLUGGABLE_CPUS[@]} -eq ${#ALL_CPUS[@]} ]; then
 		(( max_offline-- ))
 	fi
 	for cpu in "${HOTPLUGGABLE_CPUS[@]}"; do

--- a/tests/loop/002
+++ b/tests/loop/002
@@ -29,7 +29,7 @@ test() {
 
 	local sysfs="/sys/block/${loop_dev#/dev/}"
 	for blksize in "" 4096 2048 1234 1024 512; do
-		if [[ -z $blksize ]]; then
+		if [ -z $blksize ]; then
 			echo "Checking default block size"
 		else
 			echo "Setting block size to $blksize"

--- a/tests/loop/006
+++ b/tests/loop/006
@@ -63,7 +63,7 @@ test() {
 
 	# Clean up devices
 	top_dev=$(losetup -j "$loop_dev" | sed -e 's/\([^:]*\): .*/\1/')
-	if [[ -n "$top_dev" ]]; then
+	if [ -n "$top_dev" ]; then
 		losetup -d "$top_dev"
 	fi
 	losetup -d "$loop_dev"

--- a/tests/loop/rc
+++ b/tests/loop/rc
@@ -12,7 +12,7 @@ group_requires() {
 
 _have_loop_set_block_size() {
 	src/loblksize "$(losetup -f)" 512 &>/dev/null
-	if [[ $? -eq 2 ]]; then
+	if [ $? -eq 2 ]; then
 		SKIP_REASON="kernel does not support LOOP_SET_BLOCK_SIZE"
 		return 1
 	fi

--- a/tests/meta/rc
+++ b/tests/meta/rc
@@ -7,7 +7,7 @@
 . common/rc
 
 group_requires() {
-	if [[ -v META_REQUIRES_SKIP ]]; then
+	if [ -n "$META_REQUIRES_SKIP" ]; then
 		SKIP_REASON="META_REQUIRES_SKIP was set"
 		return 1
 	fi
@@ -15,7 +15,7 @@ group_requires() {
 }
 
 group_device_requires() {
-	if [[ -v META_DEVICE_REQUIRES_SKIP ]]; then
+	if [ -n "$META_DEVICE_REQUIRES_SKIP" ]; then
 		SKIP_REASON="META_DEVICE_REQUIRES_SKIP was set"
 		return 1
 	fi
@@ -23,7 +23,7 @@ group_device_requires() {
 }
 
 _have_writeable_kmsg() {
-	if [[ ! -w /dev/kmsg ]]; then
+	if [ ! -w /dev/kmsg ]; then
 		SKIP_REASON="cannot write to /dev/kmsg"
 		return 1
 	fi

--- a/tests/nbd/rc
+++ b/tests/nbd/rc
@@ -43,7 +43,7 @@ _have_nbd_netlink() {
 
 _wait_for_nbd_connect() {
 	for ((i = 0; i < 3; i++)); do
-		if [[ -e /sys/kernel/debug/nbd/nbd0/tasks ]]; then
+		if [ -e /sys/kernel/debug/nbd/nbd0/tasks ]; then
 			return 0
 		fi
 		sleep 1
@@ -53,7 +53,7 @@ _wait_for_nbd_connect() {
 
 _wait_for_nbd_disconnect() {
 	for ((i = 0; i < 3; i++)); do
-		if [[ ! -e /sys/kernel/debug/nbd/nbd0/tasks ]]; then
+		if [ ! -e /sys/kernel/debug/nbd/nbd0/tasks ]; then
 			return 0
 		fi
 		sleep 1

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -29,7 +29,7 @@ _create_nvmet_port() {
 
 	local port
 	for ((port = 0; ; port++)); do
-		if [[ ! -e "${NVMET_CFS}/ports/${port}" ]]; then
+		if [ ! -e "${NVMET_CFS}/ports/${port}" ]; then
 			break
 		fi
 	done
@@ -53,7 +53,7 @@ _create_nvmet_ns() {
 	local subsys_path="${NVMET_CFS}/subsystems/${nvmet_subsystem}"
 	local ns_path="${subsys_path}/namespaces/${nsid}"
 
-	if [[ $# -eq 4 ]]; then
+	if [ $# -eq 4 ]; then
 		uuid="$4"
 	fi
 
@@ -113,7 +113,7 @@ _find_nvme_loop_dev() {
 	for dev in /sys/class/nvme/nvme*; do
 		dev="$(basename "$dev")"
 		transport="$(cat "/sys/class/nvme/${dev}/transport")"
-		if [[ "$transport" == "loop" ]]; then
+		if [ "$transport" == "loop" ]; then
 			echo "$dev"
 		fi
 	done

--- a/tests/scsi/rc
+++ b/tests/scsi/rc
@@ -19,7 +19,7 @@ _have_scsi_generic() {
 }
 
 _test_dev_is_scsi() {
-	if [[ ! -d ${TEST_DEV_SYSFS}/device/scsi_device ]]; then
+	if [ ! -d "${TEST_DEV_SYSFS}/device/scsi_device" ]; then
 		SKIP_REASON="$TEST_DEV is not a SCSI device"
 		return 1
 	fi
@@ -27,7 +27,7 @@ _test_dev_is_scsi() {
 }
 
 _test_dev_is_scsi_disk() {
-	if [[ ! -d ${TEST_DEV_SYSFS}/device/scsi_disk ]]; then
+	if [ ! -d "${TEST_DEV_SYSFS}/device/scsi_disk" ]; then
 		SKIP_REASON="$TEST_DEV is not a SCSI disk"
 		return 1
 	fi


### PR DESCRIPTION
This patch series allows to run blktests on systems with an older version of bash and that neither have the realpath nor the findmnt executable.