### PR TITLE
src/sg/syzkaller1.c: fix portability problem for syscall(__NR_mmap, ...)

### DIFF
--- a/src/sg/syzkaller1.c
+++ b/src/sg/syzkaller1.c
@@ -401,8 +401,10 @@ long r[15];
 void test()
 {
   memset(r, -1, sizeof(r));
-  r[0] = execute_syscall(__NR_mmap, 0x20000000ul, 0x5000ul, 0x3ul,
-                         0x32ul, (uintptr_t)(-1ul), 0x0ul, 0, 0, 0);
+//r[0] = execute_syscall(__NR_mmap, 0x20000000ul, 0x5000ul, 0x3ul,
+//                       0x32ul, (uintptr_t)(-1ul), 0x0ul, 0, 0, 0);
+  r[0] = (long) mmap((void *) 0x20000000, (size_t) 0x5000,
+                     PROT_READ | PROT_WRITE, MAP_FIXED | MAP_ANONYMOUS, -1, 0);
   NONFAILING(memcpy((void*)0x20000000,
                     dev_sg, strlen(dev_sg)));
   r[2] = execute_syscall(__NR_syz_open_dev, 0x20000000ul, 0x0ul, 0x2ul,


### PR DESCRIPTION
How mmap is mapped to a raw system call varies across different
architectures.  On some architectures (such as 32-bit ARM), __NR_mmap
may not exist at all; glibc will use __NR_mmap2 to implement mmap(2).
Syzkaller is using mmap() as a non-portable version of malloc(3), so
it should be safe to use the glibc's mmap wrapper instead of trying to
directly call the system call.

Signed-off-by: Theodore Ts'o <tytso@mit.edu>
Reviewed-by: Bart Van Assche <bvanassche@acm.org>

[ I found this when trying to build blktests as part of the kvm-xfstests test appliance, which I currently do for the x86_64, i386, arm64, and armhf platforms. ]