### PR TITLE
src/discontiguous-io: Build fix for 32-bit systems

### DIFF
--- a/src/discontiguous-io.cpp
+++ b/src/discontiguous-io.cpp
@@ -291,7 +291,7 @@ int main(int argc, char **argv)
 			unsigned char *p = &*buf.begin();
 			for (int i = 0; i < len / 4; i++)
 				iov.append(p + 4 + i * 8,
-					   std::min(4ul, len - i * 4));
+					   std::min((size_t)4, len - i * 4));
 		} else {
 			iov.append(&*buf.begin(), buf.size());
 		}


### PR DESCRIPTION
The size_t type is not guaranteed to be 64 bits on all systems. When compiling
using clang on a 32-bit system, the following error occurs during compilation:

discontiguous-io.cpp:294:9: error: no matching function for call to 'min'
                                           std::min(4ul, len - i * 4));
                                           ^~~~~~~~
/usr/bin/../include/c++/v1/algorithm:2568:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp'
      ('unsigned long' vs. 'unsigned int')
min(const _Tp& __a, const _Tp& __b)
^
/usr/bin/../include/c++/v1/algorithm:2578:1: note: candidate template ignored: could not match
'initializer_list<type-parameter-0-0>'
      against 'unsigned long'
min(initializer_list<_Tp> __t, _Compare __comp)
^
/usr/bin/../include/c++/v1/algorithm:2560:1: note: candidate function template not viable: requires 3 arguments, but 2 were
provided
min(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
/usr/bin/../include/c++/v1/algorithm:2586:1: note: candidate function template not viable: requires single argument '__t', but 2
arguments
      were provided
min(initializer_list<_Tp> __t)
^

This is because the 4ul was an unsigned long, but size_t was of type
unsigned int, so min did not match. Explicitly cast that constant to
a size_t so that the types being compared are always the same.

Signed-off-by: Evan Green <evangreen86@gmail.com>