### PR TITLE
blktests: common/rc, skip missing modules if they're built into the kernel

### DIFF
--- a/common/rc
+++ b/common/rc
@@ -33,6 +33,10 @@ _have_modules() {
 	local module
 
 	for module in "$@"; do
+		# check if a module is already loaded or built in.
+		if test -d "/sys/firmware/$module"; then
+			continue
+		fi
 		if ! modprobe -n -q "$module"; then
 			missing+=("$module")
 		fi


### PR DESCRIPTION
Ted complained about needing to have a bunch of things built as
modules instead of built in at LSFMM... fix this for him.

Since we still look at module_param separately, we can skip tests that
can't be unloaded though.

Signed-off-by: Kyle McMartin <jkkm@fb.com>