### PR TITLE
linux/kvm.h appears to be unnecessary (and is x86 specific)

### DIFF
--- a/src/sg/syzkaller1.c
+++ b/src/sg/syzkaller1.c
@@ -34,7 +34,7 @@
 #include <linux/if_ether.h>
 #include <linux/if_tun.h>
 #include <linux/ip.h>
-#include <linux/kvm.h>
+//#include <linux/kvm.h>
 #include <linux/sched.h>
 #include <linux/tcp.h>
 #include <net/if_arp.h>

--- a/src/sg/syzkaller1.c
+++ b/src/sg/syzkaller1.c
@@ -34,7 +34,6 @@
 #include <linux/if_ether.h>
 #include <linux/if_tun.h>
 #include <linux/ip.h>
-//#include <linux/kvm.h>
 #include <linux/sched.h>
 #include <linux/tcp.h>
 #include <net/if_arp.h>


### PR DESCRIPTION
Thanks for making this code available. I tried to compile your tools on RISCV and found an unnecessary reference to linux/kvm.h

Your comments would be appreciated.
