### PR TITLE
Improve test block/013

### DIFF
--- a/tests/block/013
+++ b/tests/block/013
@@ -27,7 +27,7 @@ test_device() {
 
 	local out
 	out="$(blockdev --rereadpt "$TEST_DEV" 2>&1)"
-	if ! grep -o "Device or resource busy" <<< "$out"; then
+	if ! echo "$out" | grep -o "Device or resource busy"; then
 		echo "$out"
 	fi
 

--- a/tests/block/013
+++ b/tests/block/013
@@ -8,7 +8,6 @@
 #
 # Regression test for commit 77032ca66f86 ("Return EBUSY from BLKRRPART for
 # mounted whole-dev fs").
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 . tests/block/rc
 


### PR DESCRIPTION
Hello,

While using `blktests`, I have found the following output for 013:

```
> ./check block/013
block/013 => sda (try BLKRRPART on a mounted device)         [failed]
    runtime  3.916s  ...  2.772s
    --- tests/block/013.out	2019-10-04 23:01:38.410271508 +0000
    +++ /root/host/blktests/results/sda/block/013.out.bad	2019-10-22 14:34:25.669382490 +0000
    @@ -1,3 +1,4 @@
     Running block/013
    -Device or resource busy
    +grep: (standard input): No such file or directory
    +blockdev: ioctl error on BLKRRPART: Device or resource busy
     Test complete
```
It's clear that the test had been successful, despite the result of the test. The `grep` action that failed to proper parse the output from `blockdev` operation.

I could not reproduce this error outside `check` script, which makes me believe that some kind of setup of script variables makes this happen. Also, this is the only test that uses the `<<<` operator and it's the only one that faces this kind of issue. Changing the operator as the commit solved this issue for me.

The following snippet shows that both ways of joining commands get the same results in our context:

```bash
#!/bin/bash

test_device() {
	echo "TESTING" > /tmp/newfile

	local out
	out="$(cat /tmp/newfile)"

	if ! grep -o "BLOCKING" <<< "$out"; then
		echo "OK"
	fi

	if ! echo $out | grep -o "BLOCKING"; then
		echo "OK"
	fi

	if grep -o "TESTING" <<< "$out"; then
		echo "OK"
	fi

	if echo $out | grep -o "TESTING"; then
		echo "OK"
	fi
}

test_device
```
As result, you should get:

```
OK
OK
TESTING
OK
TESTING
OK
```
Please let me know what you think about this change.

Thanks,
     André

System info:
- `grep (GNU grep) 3.3`
- `GNU bash, version 5.0.11(1)-release (x86_64-pc-linux-gnu)`