### PR TITLE
tests/srp/rc: Make the SRP tests pass against kernel v5.7

### DIFF
--- a/tests/srp/rc
+++ b/tests/srp/rc
@@ -102,7 +102,9 @@ use_blk_mq() {
 	)
 	(
 		cd /sys/module/scsi_mod/parameters || return $?
-		echo "$scsi_mode" >use_blk_mq || return $?
+		if [ -e use_blk_mq ]; then
+			echo "$scsi_mode" >use_blk_mq || return $?
+		fi
 	)
 
 	log_out &&


### PR DESCRIPTION
Linux kernel commit 569334014370 ("scsi: core: Delete scsi_use_blk_mq")
removed the use_blk_mq sysfs attribute. Hence only write into the
use_blk_mq sysfs attribute if it exists.

Signed-off-by: Bart Van Assche <bvanassche@acm.org>