### PR TITLE
Fix ./check: line 275: LAST_TEST_RUN["$key"]: unbound variable

### DIFF
--- a/common/multipath-over-rdma
+++ b/common/multipath-over-rdma
@@ -660,8 +660,6 @@ teardown() {
 setup_test() {
 	local i m modules
 
-	set -u
-
 	if ! shutdown_client; then
 		echo "failed to shutdown client"
 		return 1


### PR DESCRIPTION
for the srp first run where /path/to/blktests/results is empty, it will
throw errors like:

$ ./check srp/001 srp/002 srp/003 srp/004 srp/005 srp/006 srp/007 srp/008 srp/009 srp/010 srp/011 srp/012 srp/013 srp/015
srp/001 (Create and remove LUNs)----------------------------
srp/001 (Create and remove LUNs)                             [failed]

==> /tmp/stderr <==
./check: line 275: LAST_TEST_RUN["$key"]: unbound variable

==> /tmp/stdout <==
    --- tests/srp/001.out>------2020-06-09 13:44:19.000000000 +0800
    +++ /lkp/benchmarks/blktests/results/nodev/srp/001.out.bad>-2020-06-09 16:18:22.594012394 +0800
    @@ -1,3 +1,4 @@
     Configured SRP target driver
    +tests/srp/rc: line 105: use_blk_mq: Permission denied
     count_luns(): 3 <> 3
     Passed

Signed-off-by: Li Zhijian <zhijianx.li@intel.com>