### PR TITLE
tests: mark tests with CAN_BE_ZONED=1

### DIFF
--- a/tests/block/008
+++ b/tests/block/008
@@ -9,6 +9,7 @@
 
 DESCRIPTION="do IO while hotplugging CPUs"
 TIMED=1
+CAN_BE_ZONED=1
 
 requires() {
 	_have_cpu_hotplug && _have_fio

--- a/tests/block/019
+++ b/tests/block/019
@@ -8,6 +8,7 @@
 
 DESCRIPTION="break PCI link device while doing I/O"
 QUICK=1
+CAN_BE_ZONED=1
 
 requires() {
 	_have_fio && _have_program setpci

--- a/tests/nvme/032
+++ b/tests/nvme/032
@@ -13,6 +13,7 @@
 
 DESCRIPTION="test nvme pci adapter rescan/reset/remove during I/O"
 QUICK=1
+CAN_BE_ZONED=1
 
 requires() {
 	_have_fio


### PR DESCRIPTION
Zoned devices should have no issues running block/{008,019} and
nvme/032, so mark the tests with CAN_BE_ZONED=1.

Signed-off-by: Klaus Jensen <k.jensen@samsung.com>