### PR TITLE
tests/srp/rc: Fix a shellcheck warning

### DIFF
--- a/tests/srp/rc
+++ b/tests/srp/rc
@@ -516,7 +516,7 @@ start_lio_srpt() {
 	i=0
 	for r in "${vdev_path[@]}"; do
 		if [ -b "$(readlink -f "$r")" ]; then
-			oflag=(oflag=direct)
+			oflag=("oflag=direct")
 		else
 			oflag=()
 		fi


### PR DESCRIPTION
Fix the following shellcheck warning:

tests/srp/rc:519:11: warning: The = here is literal. To assign by index, use
( [index]=value ) with no spaces. To keep as literal, quote it. [SC2191]

Reported-by: Shin'ichiro Kawasaki
Signed-off-by: Bart Van Assche <bvanassche@acm.org>