### PR TITLE
common/multipath-over-rdma: fix warning ignored null byte in input

### DIFF
--- a/common/multipath-over-rdma
+++ b/common/multipath-over-rdma
@@ -406,7 +406,7 @@ has_rdma_rxe() {
 	local f
 
 	for f in /sys/class/infiniband/*/parent; do
-		if [ -e "$f" ] && [ "$(<"$f")" = "$1" ]; then
+		if [ -e "$f" ] && [ "$(tr -d '\0' <"$f")" = "$1" ]; then
 			return 0
 		fi
 	done


### PR DESCRIPTION
[blktests]# nvme_trtype=rdma ./check nvme/004
nvme/004 (test nvme and nvmet UUID NS descriptors)
    runtime  1.238s  ...
nvme/004 (test nvme and nvmet UUID NS descriptors)           [failed]ignored null byte in input
    runtime  1.238s  ...  1.237s 410: warning: command substitution: ignored null byte in input
    --- tests/nvme/004.out	2020-08-18 08:11:08.496809985 -0400
    +++ /root/blktests/results/nodev/nvme/004.out.bad	2020-08-19 10:43:02.193885685 -0400
    @@ -1,4 +1,5 @@
     Running nvme/004
    +common/multipath-over-rdma: line 409: warning: command substitution: ignored null byte in input
     91fdba0d-f87b-4c25-b80f-db7be1418b9e
     uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
     NQN:blktests-subsystem-1 disconnected 1 controller(s)

manually to reproduce:
Update one network interface with 15 chars:
[blktests]# ip a s enp0s29u1u7u3c2
5: enp0s29u1u7u3c2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN group default qlen 1000
    link/ether f0:d4:e2:e6:e1:e3 brd ff:ff:ff:ff:ff:ff
[blktests]# modprobe rdma_rxe
[blktests]# echo enp0s29u1u7u3c2 >/sys/module/rdma_rxe/parameters/add
[blktests]# cat /sys/class/infiniband/rxe0/parent
enp0s29u1u7u3c2[blktests]# f="/sys/class/infiniband/rxe0/parent"
[blktests]# echo $(<"$f")
-bash: warning: command substitution: ignored null byte in input
enp0s29u1u7u3c2
[blktests]# echo $(tr -d '\0' <"$f")
enp0s29u1u7u3c2

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>