### PR TITLE
block/022: skip test when only 1 cpu available

### DIFF
--- a/common/rc
+++ b/common/rc
@@ -181,6 +181,14 @@ _have_tracepoint() {
 	return 0
 }
 
+_require_min_cpus() {
+	if [[ $(nproc) -ge $1 ]]; then
+		return 0
+	fi
+	SKIP_REASON="minimum $1 cpus required"
+	return 1
+}
+
 _test_dev_is_rotational() {
 	[[ $(cat "${TEST_DEV_SYSFS}/queue/rotational") -ne 0 ]]
 }

--- a/tests/block/022
+++ b/tests/block/022
@@ -13,6 +13,7 @@ TIMED=1
 
 requires() {
 	_have_null_blk && _have_module_param null_blk shared_tags
+	_require_min_cpus 2
 }
 
 hotplug_test() {


### PR DESCRIPTION
Blow is fail log in single cpu node.
block/022 (Test hang caused by freeze/unfreeze sequence)     [failed]
    runtime    ...  30.138s
    --- tests/block/022.out	2020-10-09 12:43:48.000000000 +0000
    +++ /usr/local/blktests/results/nodev/block/022.out.bad	2020-10-09 13:45:18.594417401 +0000
    @@ -1,2 +1,3 @@
     Running block/022
    +taskset: failed to set pid 13212's affinity: Invalid argument
     Test complete

Signed-off-by: Xiao Liang <xiliang@redhat.com>