### PR TITLE
Create test name from most recently used test number

### DIFF
--- a/new
+++ b/new
@@ -96,13 +96,11 @@ EOF
 	echo "Created tests/${group}/rc"
 fi
 
-for ((i = 1; ; i++)); do
-	seq="$(printf "%03d" "$i")"
-	test_name="${group}/${seq}"
-	if [[ ! -e tests/${test_name} ]]; then
-		break
-	fi
+for test in tests/"$group"/+([0-9]); do
+	:
 done
+seq=${test##tests/$group/+(0)}
+test_name="${group}/$(printf "%03d" $((seq + 1)))"
 
 cat << EOF > "tests/${test_name}"
 #!/bin/bash


### PR DESCRIPTION
The 'new' script can inadvertently use a test name that was removed, ex
nvme/001, which may create confusion if identically-named tests exist
among different versions. Instead, generate a test name at the numerical
tail end of the test group.

Signed-off-by: Jon Derrick <jonathan.derrick@linux.dev>