### PR TITLE
tests/nvme/rc: Fix possible endless loop

### DIFF
--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -345,7 +345,7 @@ _nvmet_passthru_target_connect() {
 	local trtype=$1
 	local subsys_name=$2
 
-	_nvme_connect_subsys "${trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${trtype}" "${subsys_name}" || return
 	nsdev=$(_find_nvme_passthru_loop_dev "${subsys_name}")
 
 	# The following tests can race with the creation


### PR DESCRIPTION
A failed connection will cause the later endless loop, so we should return
directly in such case.

344 _nvmet_passthru_target_connect() {
345         local trtype=$1
346         local subsys_name=$2
347
348         _nvme_connect_subsys "${trtype}" "${subsys_name}" || return
349         nsdev=$(_find_nvme_passthru_loop_dev "${subsys_name}")
350
351         # The following tests can race with the creation
352         # of the device so ensure the block device exists
353         # before continuing
354         while [ ! -b "${nsdev}" ]; do sleep 1; done <<< endless loop
355
356         echo "${nsdev}"
357 }

Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>