### PR TITLE
common/rc: don't unset previous SKIP_REASON in _have_kernel_option()

### DIFF
--- a/common/rc
+++ b/common/rc
@@ -152,11 +152,13 @@ _have_configfs() {
 _have_kernel_option() {
 	local f opt=$1
 
-	SKIP_REASON="kernel $(uname -r) config not found"
+	if [[ ! -f /proc/config.gz && ! -f /boot/config-$(uname -r) ]]; then
+		SKIP_REASON="kernel $(uname -r) config not found"
+		return 1
+	fi
 	for f in /proc/config.gz /boot/config-$(uname -r); do
 		[ -e "$f" ] || continue
 		if zgrep -q "^CONFIG_${opt}=[my]$" "$f"; then
-			unset SKIP_REASON
 			return 0
 		else
 			SKIP_REASON="kernel option $opt has not been enabled"


### PR DESCRIPTION
unset previous SKIP_REASON could cause a false failure.

nvme/033 => nvme0n1 (create and connect to an NVMeOF target with a passthru controller) [failed]
    runtime  2.383s  ...  0.376s
    --- tests/nvme/033.out      2022-06-08 08:46:27.956692453 +0000
    +++ /home/lizhijian/blktests/results/nvme0n1/nvme/033.out.bad       2022-06-15 06:32:31.131001276 +0000
    @@ -1,3 +1,8 @@
     Running nvme/033
    -NQN:blktests-subsystem-1 disconnected 1 controller(s)
    +tests/nvme/rc: line 181: nvme: command not found
    +tests/nvme/033: line 19: nvme: command not found
    +tests/nvme/033: line 20: nvme: command not found
    +tests/nvme/033: line 19: nvme: command not found
    +tests/nvme/033: line 20: nvme: command not found
    ...
    (Run 'diff -u tests/nvme/033.out /home/lizhijian/blktests/results/nvme0n1/nvme/033.out.bad' to see the entire diff)

Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>