### PR TITLE
Enable 'fc' as transport for blktests

### DIFF
--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -54,16 +54,14 @@ test() {
 	# Test unauthenticated connection (should fail)
 	echo "Test unauthenticated connection (should fail)"
 	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-			     "${def_traddr}" "${def_trsvcid}" \
-			     "${hostnqn}" "${hostid}"
+			     "" "" "${hostnqn}" "${hostid}"
 
 	_nvme_disconnect_subsys "${subsys_name}"
 
 	# Test authenticated connection
 	echo "Test authenticated connection"
 	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-			     "${def_traddr}" "${def_trsvcid}" \
-			     "${hostnqn}" "${hostid}" "${hostkey}"
+			     "" "" "${hostnqn}" "${hostid}" "${hostkey}"
 
 	udevadm settle
 

--- a/tests/nvme/041.out
+++ b/tests/nvme/041.out
@@ -1,6 +1,5 @@
 Running nvme/041
 Test unauthenticated connection (should fail)
-no controller found: failed to write to nvme-fabrics device
 NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test authenticated connection
 NQN:blktests-subsystem-1 disconnected 1 controller(s)

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -57,8 +57,7 @@ test() {
 		_set_nvmet_hostkey "${hostnqn}" "${hostkey}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-				     "${def_traddr}" "${def_trsvcid}" \
-				     "${hostnqn}" "${hostid}" \
+				     "" "" "${hostnqn}" "${hostid}" \
 				     "${hostkey}"
 		udevadm settle
 
@@ -75,8 +74,7 @@ test() {
 		_set_nvmet_hostkey "${hostnqn}" "${hostkey}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-				     "${def_traddr}" "${def_trsvcid}" \
-				     "${hostnqn}" "${hostid}" \
+				     "" "" "${hostnqn}" "${hostid}" \
 				     "${hostkey}"
 
 		udevadm settle

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -54,8 +54,7 @@ test() {
 		_set_nvmet_hash "${hostnqn}" "${hash}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-				     "${def_traddr}" "${def_trsvcid}" \
-				     "${hostnqn}" "${hostid}" \
+				     "" "" "${hostnqn}" "${hostid}" \
 				     "${hostkey}"
 
 		udevadm settle
@@ -70,8 +69,7 @@ test() {
 		_set_nvmet_dhgroup "${hostnqn}" "${dhgroup}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-				     "${def_traddr}" "${def_trsvcid}" \
-				     "${hostnqn}" "${hostid}" \
+				     "" "" "${hostnqn}" "${hostid}" \
 				     "${hostkey}"
 
 		udevadm settle

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -64,8 +64,7 @@ test() {
 	# Step 1: Connect with host authentication only
 	echo "Test host authentication"
 	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-			     "${def_traddr}" "${def_trsvcid}" \
-			     "${hostnqn}" "${hostid}" \
+			     "" "" "${hostnqn}" "${hostid}" \
 			     "${hostkey}"
 
 	udevadm settle
@@ -76,8 +75,7 @@ test() {
 	# and invalid ctrl authentication
 	echo "Test invalid ctrl authentication (should fail)"
 	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-			     "${def_traddr}" "${def_trsvcid}" \
-			     "${hostnqn}" "${hostid}" \
+			     "" "" "${hostnqn}" "${hostid}" \
 			     "${hostkey}" "${hostkey}"
 
 	udevadm settle
@@ -88,8 +86,7 @@ test() {
 	# and valid ctrl authentication
 	echo "Test valid ctrl authentication"
 	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-			     "${def_traddr}" "${def_trsvcid}" \
-			     "${hostnqn}" "${hostid}" \
+			     "" "" "${hostnqn}" "${hostid}" \
 			     "${hostkey}" "${ctrlkey}"
 
 	udevadm settle
@@ -101,8 +98,7 @@ test() {
 	echo "Test invalid ctrl key (should fail)"
 	invkey="DHHC-1:00:Jc/My1o0qtLCWRp+sHhAVafdfaS7YQOMYhk9zSmlatobqB8C:"
 	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-			     "${def_traddr}" "${def_trsvcid}" \
-			     "${hostnqn}" "${hostid}" \
+			     "" "" "${hostnqn}" "${hostid}" \
 			     "${hostkey}" "${invkey}"
 
 	udevadm settle

--- a/tests/nvme/044.out
+++ b/tests/nvme/044.out
@@ -2,11 +2,9 @@ Running nvme/044
 Test host authentication
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test invalid ctrl authentication (should fail)
-no controller found: failed to write to nvme-fabrics device
 NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test valid ctrl authentication
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test invalid ctrl key (should fail)
-no controller found: failed to write to nvme-fabrics device
 NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test complete

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -63,8 +63,7 @@ test() {
 	_set_nvmet_dhgroup "${hostnqn}" "ffdhe2048"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
-			     "${def_traddr}" "${def_trsvcid}" \
-			     "${hostnqn}" "${hostid}" \
+			     "" "" "${hostnqn}" "${hostid}" \
 			     "${hostkey}" "${ctrlkey}"
 
 	udevadm settle

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -343,7 +343,7 @@ _nvme_connect_subsys() {
 	if [[ -n "${ctrlkey}" ]]; then
 		ARGS+=(--dhchap-ctrl-secret="${ctrlkey}")
 	fi
-	nvme connect "${ARGS[@]}"
+	nvme connect "${ARGS[@]}" 2> /dev/null
 }
 
 _nvme_discover() {

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -10,6 +10,10 @@
 def_traddr="127.0.0.1"
 def_adrfam="ipv4"
 def_trsvcid="4420"
+def_remote_wwnn="0x10001100aa000001"
+def_remote_wwpn="0x20001100aa000001"
+def_local_wwnn="0x10001100aa000002"
+def_local_wwpn="0x20001100aa000002"
 def_hostnqn="$(cat /etc/nvme/hostnqn 2> /dev/null)"
 def_hostid="$(cat /etc/nvme/hostid 2> /dev/null)"
 nvme_trtype=${nvme_trtype:-"loop"}
@@ -36,6 +40,12 @@ _nvme_requires() {
 		_have_program rdma
 		_have_driver rdma_rxe || _have_driver siw
 		;;
+	fc)
+		_have_driver nvme-fc
+		_have_driver nvme-fcloop
+		_have_configfs
+		def_adrfam="fc"
+		;;
 	*)
 		SKIP_REASONS+=("unsupported nvme_trtype=${nvme_trtype}")
 		return 1
@@ -49,6 +59,9 @@ _nvme_requires() {
 			;;
 		ipv4)
 			;; # was already set
+		fc)
+			def_adrfam="fc"
+			;;
 		*)
 			# ignore for non ip transports
 			if [[ "${nvme_trtype}" == "tcp" ||
@@ -112,6 +125,82 @@ _test_dev_nvme_nsid() {
 	cat "${TEST_DEV_SYSFS}/nsid"
 }
 
+_nvme_fcloop_add_rport() {
+	local local_wwnn="$1"
+	local local_wwpn="$2"
+	local remote_wwnn="$3"
+	local remote_wwpn="$4"
+	local loopctl=/sys/class/fcloop/ctl
+
+	echo "wwnn=${remote_wwnn},wwpn=${remote_wwpn},lpwwnn=${local_wwnn},lpwwpn=${local_wwpn},roles=0x60" > ${loopctl}/add_remote_port
+}
+
+_nvme_fcloop_add_lport() {
+	local wwnn="$1"
+	local wwpn="$2"
+	local loopctl=/sys/class/fcloop/ctl
+
+	echo "wwnn=${wwnn},wwpn=${wwpn}" > ${loopctl}/add_local_port
+}
+
+_nvme_fcloop_add_tport() {
+	local wwnn="$1"
+	local wwpn="$2"
+	local loopctl=/sys/class/fcloop/ctl
+
+	echo "wwnn=${wwnn},wwpn=${wwpn}" > ${loopctl}/add_target_port
+}
+
+_setup_fcloop() {
+	local local_wwnn="${1:-$def_local_wwnn}"
+	local local_wwpn="${2:-$def_local_wwpn}"
+	local remote_wwnn="${3:-$def_remote_wwnn}"
+	local remote_wwpn="${4:-$def_remote_wwpn}"
+
+	_nvme_fcloop_add_tport ${remote_wwnn} ${remote_wwpn}
+	_nvme_fcloop_add_lport ${local_wwnn} ${local_wwpn}
+	_nvme_fcloop_add_rport ${local_wwnn} ${local_wwpn} \
+			       ${remote_wwnn} ${remote_wwpn}
+}
+
+_nvme_fcloop_del_rport() {
+	local local_wwnn="$1"
+	local local_wwpn="$2"
+	local remote_wwnn="$3"
+	local remote_wwpn="$4"
+	local loopctl=/sys/class/fcloop/ctl
+
+	echo "wwnn=${remote_wwnn},wwpn=${remote_wwpn}" > ${loopctl}/del_remote_port 2> /dev/null
+}
+
+_nvme_fcloop_del_lport() {
+	local wwnn="$1"
+	local wwpn="$2"
+	local loopctl=/sys/class/fcloop/ctl
+
+	echo "wwnn=${wwnn},wwpn=${wwpn}" > ${loopctl}/del_local_port 2> /dev/null
+}
+
+_nvme_fcloop_del_tport() {
+	local wwnn="$1"
+	local wwpn="$2"
+	local loopctl=/sys/class/fcloop/ctl
+
+	echo "wwnn=${wwnn},wwpn=${wwpn}" > ${loopctl}/del_target_port 2> /dev/null
+}
+
+_cleanup_fcloop() {
+	local local_wwnn="${1:-$def_local_wwnn}"
+	local local_wwpn="${2:-$def_local_wwpn}"
+	local remote_wwnn="${3:-$def_remote_wwnn}"
+	local remote_wwpn="${4:-$def_remote_wwpn}"
+
+	_nvme_fcloop_del_rport "${local_wwnn}" "${local_wwpn}" \
+			       "${remote_wwnn}" "${remote_wwpn}"
+	_nvme_fcloop_del_tport "${remote_wwnn}" "${remote_wwpn}"
+	_nvme_fcloop_del_lport "${local_wwnn}" "${local_wwpn}"
+}
+
 _cleanup_nvmet() {
 	local dev
 	local port
@@ -170,6 +259,9 @@ _cleanup_nvmet() {
 	if [[ "${nvme_trtype}" == "rdma" ]]; then
 		stop_soft_rdma
 	fi
+	if [[ "${nvme_trtype}" == "fc" ]]; then
+		_cleanup_fcloop
+	fi
 }
 
 _setup_nvmet() {
@@ -196,6 +288,16 @@ _setup_nvmet() {
 			fi
 		done
 	fi
+	if [[ "${nvme_trtype}" = "fc" ]]; then
+		modprobe -q nvme-fcloop
+		_setup_fcloop
+		def_traddr=$(printf "nn-%s:pn-%s" \
+				    "${def_remote_wwnn}" \
+				    "${def_remote_wwpn}")
+		def_host_traddr=$(printf "nn-%s:pn-%s" \
+					 "${def_local_wwnn}" \
+					 "${def_local_wwpn}")
+	fi
 }
 
 _nvme_disconnect_ctrl() {
@@ -214,6 +316,7 @@ _nvme_connect_subsys() {
 	local trtype="$1"
 	local subsysnqn="$2"
 	local traddr="${3:-$def_traddr}"
+	local host_traddr="${4:-$def_host_traddr}"
 	local trsvcid="${4:-$def_trsvcid}"
 	local hostnqn="${5:-$def_hostnqn}"
 	local hostid="${6:-$def_hostid}"
@@ -222,7 +325,11 @@ _nvme_connect_subsys() {
 
 	ARGS=(-t "${trtype}" -n "${subsysnqn}")
 	if [[ "${trtype}" != "loop" ]]; then
-		ARGS+=(-a "${traddr}" -s "${trsvcid}")
+		if [[ "${trtype}" == "fc" ]] ; then
+			ARGS+=(-a "${traddr}" -w "${host_traddr}")
+		else
+			ARGS+=(-a "${traddr}" -s "${trsvcid}")
+		fi
 	fi
 	if [[ "${hostnqn}" != "$def_hostnqn" ]]; then
 		ARGS+=(--hostnqn="${hostnqn}")
@@ -242,11 +349,16 @@ _nvme_connect_subsys() {
 _nvme_discover() {
 	local trtype="$1"
 	local traddr="${2:-$def_traddr}"
+	local host_traddr="${3:-$def_host_traddr}"
 	local trsvcid="${3:-$def_trsvcid}"
 
 	ARGS=(-t "${trtype}")
 	if [[ "${trtype}" != "loop" ]]; then
-		ARGS+=(-a "${traddr}" -s "${trsvcid}")
+		if [[ "${trtype}" = "fc" ]]; then
+			ARGS+=(-a "${traddr}" -w "${host_traddr}")
+		else
+			ARGS+=(-a "${traddr}" -s "${trsvcid}")
+		fi
 	fi
 	nvme discover "${ARGS[@]}"
 }
@@ -264,11 +376,16 @@ _create_nvmet_port() {
 		fi
 	done
 
+	if [[ "${adrfam}" = "fc" ]]; then
+		trsvcid=
+	fi
 	mkdir "${NVMET_CFS}/ports/${port}"
 	echo "${trtype}" > "${NVMET_CFS}/ports/${port}/addr_trtype"
 	echo "${traddr}" > "${NVMET_CFS}/ports/${port}/addr_traddr"
 	echo "${adrfam}" > "${NVMET_CFS}/ports/${port}/addr_adrfam"
-	echo "${trsvcid}" > "${NVMET_CFS}/ports/${port}/addr_trsvcid"
+	if [[ "${trsvcid}" ]]; then
+		echo "${trsvcid}" > "${NVMET_CFS}/ports/${port}/addr_trsvcid"
+	fi
 
 	echo "${port}"
 }


### PR DESCRIPTION
Hi all,

this patchset adds support for the 'fc' transport in blktests by configuring the 'fcloop' device. This allows to validate the nvme-fc transport in addition to the existing 'loop', 'tcp', and 'rdma' transports.
