### PR TITLE
srp/016: Add a test that triggers RDMA hot-unplug

### DIFF
--- a/tests/srp/016
+++ b/tests/srp/016
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0+
+# Copyright 2022 Google LLC
+
+. tests/srp/rc
+
+DESCRIPTION="RDMA hot-unplug"
+QUICK=1
+
+test_hot_unplug() {
+	use_blk_mq y y || return $?
+	# This triggers a use-after-free with older kernels. See also
+	# https://lore.kernel.org/linux-rdma/17649b9c-7e42-1625-8bc9-8ad333ab771c@fujitsu.com/
+	stop_soft_rdma
+}
+
+test() {
+	trap 'trap "" EXIT; teardown' EXIT
+	setup && test_hot_unplug && echo Passed
+}

--- a/tests/srp/016.out
+++ b/tests/srp/016.out
@@ -1,0 +1,2 @@
+Configured SRP target driver
+Passed


### PR DESCRIPTION
Kernel commit 8fe4ce5836e9 ("scsi: core: Fix a use-after-free"; v6.0-rc5) fixes a kernel crash triggered by RDMA hot-unplug. This test triggers RDMA hot-unplug and also triggers a kernel crash without the aforementioned kernel commit.

Cc: Li Zhijian <lizhijian@fujitsu.com>
Signed-off-by: Bart Van Assche <bvanassche@acm.org>