### PR TITLE
nvme/041,044: fix failure output

### DIFF
--- a/tests/nvme/041.out
+++ b/tests/nvme/041.out
@@ -1,5 +1,6 @@
 Running nvme/041
 Test unauthenticated connection (should fail)
+Failed to write to /dev/nvme-fabrics: Input/output error
 no controller found: failed to write to nvme-fabrics device
 NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test authenticated connection

--- a/tests/nvme/044.out
+++ b/tests/nvme/044.out
@@ -2,11 +2,13 @@ Running nvme/044
 Test host authentication
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test invalid ctrl authentication (should fail)
+Failed to write to /dev/nvme-fabrics: Input/output error
 no controller found: failed to write to nvme-fabrics device
 NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test valid ctrl authentication
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test invalid ctrl key (should fail)
+Failed to write to /dev/nvme-fabrics: Input/output error
 no controller found: failed to write to nvme-fabrics device
 NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test complete


### PR DESCRIPTION
$ ./check nvme/041 nvme/044
nvme/041 (Create authenticated connections)                  [failed]
    runtime  1.173s  ...  1.217s
    --- tests/nvme/041.out	2022-10-08 22:30:04.602755863 -0400
    +++ /mnt/tests/kernel/storage/SSD/nvme_blktest/blktests/results/nodev/nvme/041.out.bad	2022-10-08 22:30:12.839073819 -0400
    @@ -1,5 +1,6 @@
     Running nvme/041
     Test unauthenticated connection (should fail)
    +Failed to write to /dev/nvme-fabrics: Input/output error
     no controller found: failed to write to nvme-fabrics device
     NQN:blktests-subsystem-1 disconnected 0 controller(s)
     Test authenticated connection
nvme/044 (Test bi-directional authentication)                [failed]
    runtime  2.952s  ...  2.917s
    --- tests/nvme/044.out	2022-10-08 22:30:04.602755863 -0400
    +++ /mnt/tests/kernel/storage/SSD/nvme_blktest/blktests/results/nodev/nvme/044.out.bad	2022-10-08 22:30:16.036197242 -0400
    @@ -2,11 +2,13 @@
     Test host authentication
     NQN:blktests-subsystem-1 disconnected 1 controller(s)
     Test invalid ctrl authentication (should fail)
    +Failed to write to /dev/nvme-fabrics: Input/output error
     no controller found: failed to write to nvme-fabrics device
     NQN:blktests-subsystem-1 disconnected 0 controller(s)
     Test valid ctrl authentication
    ...
    (Run 'diff -u tests/nvme/044.out /mnt/tests/kernel/storage/SSD/nvme_blktest/blktests/results/nodev/nvme/044.out.bad' to see the entire diff)

Signed-off-by: Yi Zhang <yi.zhang@redhat.com>