### PR TITLE
common/null_blk: Do not pass an empty string to modprobe

### DIFF
--- a/common/null_blk
+++ b/common/null_blk
@@ -20,10 +20,10 @@ _remove_null_blk_devices() {
 _init_null_blk() {
 	_remove_null_blk_devices
 
-	local zoned=""
-	if (( RUN_FOR_ZONED )); then zoned="zoned=1"; fi
+	local args=("$@")
+	if (( RUN_FOR_ZONED )); then args+=("zoned=1"); fi
 
-	if ! modprobe -r null_blk || ! modprobe null_blk "$@" "${zoned}" ; then
+	if ! modprobe -r null_blk || ! modprobe null_blk "${args[@]}" ; then
 		SKIP_REASONS+=("requires modular null_blk")
 		return 1
 	fi


### PR DESCRIPTION
_init_null_blk() passes an empty string as last argument to modprobe if RUN_FOR_ZONED is false. Fix this.

Fixes: e840e1537dc6 ("config: Introduce RUN_ZONED_TESTS variable and CAN_BE_ZONED flag")
Signed-off-by: Bart Van Assche <bvanassche@acm.org>