### PR TITLE
Fix multiple shellcheck warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,7 @@ install:
 	cp -R tests common $(dest)
 	$(MAKE) -C src dest=$(dest)/src install
 
-# SC2119: "Use foo "$@" if function's $1 should mean script's $1". False
-# positives on helpers like _init_scsi_debug.
-SHELLCHECK_EXCLUDE := SC2119
+SHELLCHECK_EXCLUDE := ""
 
 check:
 	shellcheck -x -e $(SHELLCHECK_EXCLUDE) -f gcc check new common/* \

--- a/common/multipath-over-rdma
+++ b/common/multipath-over-rdma
@@ -131,7 +131,7 @@ sleep_until() {
 
 # Kill all processes that have opened block device $1.
 stop_bdev_users() {
-	[ -n "$1" ] || return $?
+	[ -n "$1" ] || return 1
 	lsof -F p "$1" 2>/dev/null | while read -r line; do
 		p="${line#p}"
 		if [ "$p" != "$line" ]; then

--- a/common/null_blk
+++ b/common/null_blk
@@ -44,14 +44,14 @@ _configure_null_blk() {
 	mkdir "$nullb" || return $?
 
 	if (( RUN_FOR_ZONED )); then
-		echo "1" > "$nullb/zoned" || return $?
+		echo "1" > "$nullb/zoned" || return 1
 	fi
 
 	while [[ $# -gt 0 ]]; do
 		param="${1%%=*}"
 		val="${1#*=}"
 		shift
-		echo "$val" > "$nullb/$param" || return $?
+		echo "$val" > "$nullb/$param" || return 1
 	done
 }
 

--- a/tests/block/002
+++ b/tests/block/002
@@ -18,7 +18,7 @@ requires() {
 test() {
 	echo "Running ${TEST_NAME}"
 
-	if ! _init_scsi_debug; then
+	if ! _init_scsi_debug delay=0; then
 		return 1
 	fi
 

--- a/tests/nvmeof-mp/rc
+++ b/tests/nvmeof-mp/rc
@@ -72,7 +72,7 @@ use_blk_mq() {
 	(
 		cd /sys/module/dm_mod/parameters || return $?
 		if [ -e use_blk_mq ]; then
-			echo "$dm_mode" >use_blk_mq || return $?
+			echo "$dm_mode" >use_blk_mq || return 1
 		fi
 	)
 
@@ -115,8 +115,8 @@ log_out() {
 simulate_network_failure_loop() {
 	local d dev="$1" duration="$2" deadline i rc=0 sf
 
-	[ -e "$dev" ] || return $?
-	[ -n "$duration" ] || return $?
+	[ -e "$dev" ] || return 1
+	[ -n "$duration" ] || return 1
 	deadline=$(($(_uptime_s) + duration))
 	while [ $rc = 0 ]; do
 		sleep_until 5 ${deadline} || break

--- a/tests/scsi/007
+++ b/tests/scsi/007
@@ -28,7 +28,7 @@ test() {
 
 	echo "Running ${TEST_NAME}"
 
-	if ! _init_scsi_debug; then
+	if ! _init_scsi_debug delay=0; then
 		return 1
 	fi
 

--- a/tests/srp/014
+++ b/tests/srp/014
@@ -54,7 +54,7 @@ make_all_running() {
 set_running_loop() {
 	local dev="$1"
 
-	[ -e "$dev" ] || return $?
+	[ -e "$dev" ] || return 1
 	while true; do
 		sleep 1
 		make_all_running "$dev"
@@ -66,8 +66,8 @@ set_running_loop() {
 sg_reset_loop() {
 	local cmd dev="$1" duration="$2" deadline i=0 reset_type
 
-	[ -e "$dev" ] || return $?
-	[ -n "$duration" ] || return $?
+	[ -e "$dev" ] || return 1
+	[ -n "$duration" ] || return 1
 	reset_type=(-d -b)
 	deadline=$(($(_uptime_s) + duration))
 	while true; do

--- a/tests/srp/rc
+++ b/tests/srp/rc
@@ -96,13 +96,13 @@ use_blk_mq() {
 	(
 		cd /sys/module/dm_mod/parameters || return $?
 		if [ -e use_blk_mq ]; then
-			echo "$dm_mode" >use_blk_mq || return $?
+			echo "$dm_mode" >use_blk_mq || return 1
 		fi
 	)
 	(
 		cd /sys/module/scsi_mod/parameters || return $?
 		if [ -e use_blk_mq ]; then
-			echo "$scsi_mode" >use_blk_mq || return $?
+			echo "$scsi_mode" >use_blk_mq || return 1
 		fi
 	)
 
@@ -260,8 +260,8 @@ log_out() {
 simulate_network_failure_loop() {
 	local d dev="$1" duration="$2" deadline i rc=0 s
 
-	[ -e "$dev" ] || return $?
-	[ -n "$duration" ] || return $?
+	[ -e "$dev" ] || return 1
+	[ -n "$duration" ] || return 1
 	deadline=$(($(_uptime_s) + duration))
 	s=5
 	while [ $rc = 0 ]; do
@@ -520,7 +520,7 @@ start_lio_srpt() {
 		cd srpt || return $?
 		if [ -e discovery_auth/rdma_cm_port ]; then
 			echo "${srp_rdma_cm_port}" > discovery_auth/rdma_cm_port ||
-				return $?
+				return 1
 		fi
 		configure_target_ports "${target_ids[@]}" -- "${ini_ids[@]}"
 	)

--- a/tests/zbd/003
+++ b/tests/zbd/003
@@ -43,7 +43,7 @@ test_device() {
 
 	# Select 2 target zones so that reset zone range also get tested
 	_get_blkzone_report "${TEST_DEV}" || return $?
-	zone_idx=$(_find_two_contiguous_seq_zones) || return $?
+	zone_idx=$(_find_two_contiguous_seq_zones "") || return $?
 	target_zones=( "${zone_idx}" "$((zone_idx + 1))" )
 
 	# Reset the 2 target zones and write 4KB in each zone to increment

--- a/tests/zbd/rc
+++ b/tests/zbd/rc
@@ -269,7 +269,7 @@ _find_two_contiguous_seq_zones() {
 	for ((idx = NR_CONV_ZONES; idx < REPORTED_COUNT; idx++)); do
 		if [[ ${ZONE_TYPES[idx]} -eq ${type_seq} &&
 		      ${ZONE_TYPES[idx+1]} -eq ${type_seq} ]]; then
-			if [[ -n ${cap_eq_len} ]] &&
+			if [[ ${cap_eq_len} = "cap_eq_len" ]] &&
 				   ((ZONE_CAPS[idx] != ZONE_LENGTHS[idx])); then
 				continue
 			fi

--- a/tests/zbd/rc
+++ b/tests/zbd/rc
@@ -125,7 +125,7 @@ _get_blkzone_report() {
 	TMP_REPORT_FILE=${TMPDIR}/blkzone_report
 	if ! blkzone report "${target_dev}" > "${TMP_REPORT_FILE}"; then
 		echo "blkzone command failed"
-		return $?
+		return 1
 	fi
 
 	cap_idx=3

--- a/tests/zbd/rc
+++ b/tests/zbd/rc
@@ -80,21 +80,21 @@ _get_sysfs_variable() {
 	unset SYSFS_VARS
 	local _dir=${TEST_DEV_SYSFS}
 	if _test_dev_is_partition; then
-		SYSFS_VARS[$SV_CAPACITY]=$(<"${TEST_DEV_PART_SYSFS}"/size)
+		SYSFS_VARS[SV_CAPACITY]=$(<"${TEST_DEV_PART_SYSFS}"/size)
 	else
-		SYSFS_VARS[$SV_CAPACITY]=$(<"${_dir}"/size)
+		SYSFS_VARS[SV_CAPACITY]=$(<"${_dir}"/size)
 	fi
-	SYSFS_VARS[$SV_CHUNK_SECTORS]=$(<"${_dir}"/queue/chunk_sectors)
-	SYSFS_VARS[$SV_PHYS_BLK_SIZE]=$(<"${_dir}"/queue/physical_block_size)
-	SYSFS_VARS[$SV_PHYS_BLK_SECTORS]=$((SYSFS_VARS[SV_PHYS_BLK_SIZE] / 512))
+	SYSFS_VARS[SV_CHUNK_SECTORS]=$(<"${_dir}"/queue/chunk_sectors)
+	SYSFS_VARS[SV_PHYS_BLK_SIZE]=$(<"${_dir}"/queue/physical_block_size)
+	SYSFS_VARS[SV_PHYS_BLK_SECTORS]=$((SYSFS_VARS[SV_PHYS_BLK_SIZE] / 512))
 
 	# If the nr_zones sysfs attribute exists, get its value. Otherwise,
 	# calculate its value based on the total capacity and zone size, taking
 	# into account that the last zone can be smaller than other zones.
 	if [[ -e "${_dir}"/queue/nr_zones ]] && ! _test_dev_is_partition; then
-		SYSFS_VARS[$SV_NR_ZONES]=$(<"${_dir}"/queue/nr_zones)
+		SYSFS_VARS[SV_NR_ZONES]=$(<"${_dir}"/queue/nr_zones)
 	else
-		SYSFS_VARS[$SV_NR_ZONES]=$(( (SYSFS_VARS[SV_CAPACITY] - 1) \
+		SYSFS_VARS[SV_NR_ZONES]=$(( (SYSFS_VARS[SV_CAPACITY] - 1) \
 				/ SYSFS_VARS[SV_CHUNK_SECTORS] + 1 ))
 	fi
 }


### PR DESCRIPTION
Suppress three shellcheck warnings: two warnings that are not useful and another warning that is reported in contexts where it does not apply.

Signed-off-by: Bart Van Assche <bvanassche@acm.org>