### PR TITLE
tests/block/007: Rework I/O polling

### DIFF
--- a/common/iopoll
+++ b/common/iopoll
@@ -17,19 +17,6 @@ _have_fio_with_poll() {
 	return 0
 }
 
-_require_test_dev_supports_io_poll() {
-	local old_io_poll
-	if ! old_io_poll="$(cat "${TEST_DEV_SYSFS}/queue/io_poll" 2>/dev/null)"; then
-		SKIP_REASONS+=("kernel does not support polling")
-		return 1
-	fi
-	if ! echo "$old_io_poll" >"${TEST_DEV_SYSFS}/queue/io_poll" 2>/dev/null; then
-		SKIP_REASONS+=("$TEST_DEV does not support polling")
-		return 1
-	fi
-	return 0
-}
-
 _require_test_dev_supports_io_poll_delay() {
 	local old_io_poll_delay
 	if ! old_io_poll_delay="$(cat "${TEST_DEV_SYSFS}/queue/io_poll_delay" 2>/dev/null)"; then

--- a/tests/block/007
+++ b/tests/block/007
@@ -16,8 +16,7 @@ requires() {
 }
 
 device_requires() {
-	_require_test_dev_supports_io_poll &&
-		_require_test_dev_supports_io_poll_delay
+	_require_test_dev_supports_io_poll_delay
 }
 
 fallback_device() {
@@ -40,7 +39,7 @@ run_fio_job() {
 
 	_fio_perf --bs=4k --rw=randread --norandommap --name=reads \
 		--filename="$TEST_DEV" --size="$size" --direct=1 \
-		--ioengine=pvsync2 --hipri=1
+		--ioengine=pvsync2 --hipri="$1"
 }
 
 test_device() {
@@ -51,24 +50,22 @@ test_device() {
 
 	# no polling, run job
 	FIO_PERF_PREFIX="no poll "
-	_test_dev_queue_set io_poll 0
-	run_fio_job
+	run_fio_job 0
 
 	# turn on polling, switch to classic, run job
 	FIO_PERF_PREFIX="classic poll "
-	_test_dev_queue_set io_poll 1
 	_test_dev_queue_set io_poll_delay -1
-	run_fio_job
+	run_fio_job 1
 
 	# switch to auto-hybrid polling, run job
 	FIO_PERF_PREFIX="auto hybrid poll "
 	_test_dev_queue_set io_poll_delay 0
-	run_fio_job
+	run_fio_job 1
 
 	# switch to explicit delay polling, run job
 	FIO_PERF_PREFIX="fixed hybrid poll "
 	_test_dev_queue_set io_poll_delay 4
-	run_fio_job
+	run_fio_job 1
 
 	echo "Test complete"
 }


### PR DESCRIPTION
Linux kernel commit a614dd228035 ("block: don't allow writing to the poll queue attribute") makes writes into /sys/block/*/queue/io_poll a no-op. Rework test block/007 such that it no longer uses that attribute.

Signed-off-by: Bart Van Assche <bvanassche@acm.org>