### PR TITLE
src/discontiguous-io.cpp: Fix the build

### DIFF
--- a/src/discontiguous-io.cpp
+++ b/src/discontiguous-io.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2016-2018 Western Digital Corporation or its affiliates
 
 #include <cassert>
+#include <cstdint>     // uintptr_t
 #include <cstring>     // memset()
 #include <fcntl.h>     // O_RDONLY
 #include <iomanip>


### PR DESCRIPTION
Fix the following build error:

g++  -O2 -std=c++11 -Wall -Wextra -Wshadow -Wno-sign-compare -Werror -DHAVE_LINUX_BLKZONED_H -o discontiguous-io discontiguous-io.cpp discontiguous-io.cpp: In function ‘void dumphex(std::ostream&, const void*, size_t)’: discontiguous-io.cpp:92:24: error: ‘uintptr_t’ was not declared in this scope

Signed-off-by: Bart Van Assche <bvanassche@acm.org>