### PR TITLE
Update tests for discovery log page changes

### DIFF
--- a/tests/nvme/002.out
+++ b/tests/nvme/002.out
@@ -1,3003 +1,3006 @@
 Running nvme/002
-Discovery Log Number of Records 1000, Generation counter X
+Discovery Log Number of Records 1001, Generation counter X
 =====Discovery Log Entry 0======
 trtype:  loop
-subnqn:  blktests-subsystem-0
+subnqn:  nqn.2014-08.org.nvmexpress.discovery
 =====Discovery Log Entry 1======
 trtype:  loop
-subnqn:  blktests-subsystem-1
+subnqn:  blktests-subsystem-0
 =====Discovery Log Entry 2======
 trtype:  loop
-subnqn:  blktests-subsystem-2
+subnqn:  blktests-subsystem-1
 =====Discovery Log Entry 3======
 trtype:  loop
-subnqn:  blktests-subsystem-3
+subnqn:  blktests-subsystem-2
 =====Discovery Log Entry 4======
 trtype:  loop
-subnqn:  blktests-subsystem-4
+subnqn:  blktests-subsystem-3
 =====Discovery Log Entry 5======
 trtype:  loop
-subnqn:  blktests-subsystem-5
+subnqn:  blktests-subsystem-4
 =====Discovery Log Entry 6======
 trtype:  loop
-subnqn:  blktests-subsystem-6
+subnqn:  blktests-subsystem-5
 =====Discovery Log Entry 7======
 trtype:  loop
-subnqn:  blktests-subsystem-7
+subnqn:  blktests-subsystem-6
 =====Discovery Log Entry 8======
 trtype:  loop
-subnqn:  blktests-subsystem-8
+subnqn:  blktests-subsystem-7
 =====Discovery Log Entry 9======
 trtype:  loop
-subnqn:  blktests-subsystem-9
+subnqn:  blktests-subsystem-8
 =====Discovery Log Entry 10======
 trtype:  loop
-subnqn:  blktests-subsystem-10
+subnqn:  blktests-subsystem-9
 =====Discovery Log Entry 11======
 trtype:  loop
-subnqn:  blktests-subsystem-11
+subnqn:  blktests-subsystem-10
 =====Discovery Log Entry 12======
 trtype:  loop
-subnqn:  blktests-subsystem-12
+subnqn:  blktests-subsystem-11
 =====Discovery Log Entry 13======
 trtype:  loop
-subnqn:  blktests-subsystem-13
+subnqn:  blktests-subsystem-12
 =====Discovery Log Entry 14======
 trtype:  loop
-subnqn:  blktests-subsystem-14
+subnqn:  blktests-subsystem-13
 =====Discovery Log Entry 15======
 trtype:  loop
-subnqn:  blktests-subsystem-15
+subnqn:  blktests-subsystem-14
 =====Discovery Log Entry 16======
 trtype:  loop
-subnqn:  blktests-subsystem-16
+subnqn:  blktests-subsystem-15
 =====Discovery Log Entry 17======
 trtype:  loop
-subnqn:  blktests-subsystem-17
+subnqn:  blktests-subsystem-16
 =====Discovery Log Entry 18======
 trtype:  loop
-subnqn:  blktests-subsystem-18
+subnqn:  blktests-subsystem-17
 =====Discovery Log Entry 19======
 trtype:  loop
-subnqn:  blktests-subsystem-19
+subnqn:  blktests-subsystem-18
 =====Discovery Log Entry 20======
 trtype:  loop
-subnqn:  blktests-subsystem-20
+subnqn:  blktests-subsystem-19
 =====Discovery Log Entry 21======
 trtype:  loop
-subnqn:  blktests-subsystem-21
+subnqn:  blktests-subsystem-20
 =====Discovery Log Entry 22======
 trtype:  loop
-subnqn:  blktests-subsystem-22
+subnqn:  blktests-subsystem-21
 =====Discovery Log Entry 23======
 trtype:  loop
-subnqn:  blktests-subsystem-23
+subnqn:  blktests-subsystem-22
 =====Discovery Log Entry 24======
 trtype:  loop
-subnqn:  blktests-subsystem-24
+subnqn:  blktests-subsystem-23
 =====Discovery Log Entry 25======
 trtype:  loop
-subnqn:  blktests-subsystem-25
+subnqn:  blktests-subsystem-24
 =====Discovery Log Entry 26======
 trtype:  loop
-subnqn:  blktests-subsystem-26
+subnqn:  blktests-subsystem-25
 =====Discovery Log Entry 27======
 trtype:  loop
-subnqn:  blktests-subsystem-27
+subnqn:  blktests-subsystem-26
 =====Discovery Log Entry 28======
 trtype:  loop
-subnqn:  blktests-subsystem-28
+subnqn:  blktests-subsystem-27
 =====Discovery Log Entry 29======
 trtype:  loop
-subnqn:  blktests-subsystem-29
+subnqn:  blktests-subsystem-28
 =====Discovery Log Entry 30======
 trtype:  loop
-subnqn:  blktests-subsystem-30
+subnqn:  blktests-subsystem-29
 =====Discovery Log Entry 31======
 trtype:  loop
-subnqn:  blktests-subsystem-31
+subnqn:  blktests-subsystem-30
 =====Discovery Log Entry 32======
 trtype:  loop
-subnqn:  blktests-subsystem-32
+subnqn:  blktests-subsystem-31
 =====Discovery Log Entry 33======
 trtype:  loop
-subnqn:  blktests-subsystem-33
+subnqn:  blktests-subsystem-32
 =====Discovery Log Entry 34======
 trtype:  loop
-subnqn:  blktests-subsystem-34
+subnqn:  blktests-subsystem-33
 =====Discovery Log Entry 35======
 trtype:  loop
-subnqn:  blktests-subsystem-35
+subnqn:  blktests-subsystem-34
 =====Discovery Log Entry 36======
 trtype:  loop
-subnqn:  blktests-subsystem-36
+subnqn:  blktests-subsystem-35
 =====Discovery Log Entry 37======
 trtype:  loop
-subnqn:  blktests-subsystem-37
+subnqn:  blktests-subsystem-36
 =====Discovery Log Entry 38======
 trtype:  loop
-subnqn:  blktests-subsystem-38
+subnqn:  blktests-subsystem-37
 =====Discovery Log Entry 39======
 trtype:  loop
-subnqn:  blktests-subsystem-39
+subnqn:  blktests-subsystem-38
 =====Discovery Log Entry 40======
 trtype:  loop
-subnqn:  blktests-subsystem-40
+subnqn:  blktests-subsystem-39
 =====Discovery Log Entry 41======
 trtype:  loop
-subnqn:  blktests-subsystem-41
+subnqn:  blktests-subsystem-40
 =====Discovery Log Entry 42======
 trtype:  loop
-subnqn:  blktests-subsystem-42
+subnqn:  blktests-subsystem-41
 =====Discovery Log Entry 43======
 trtype:  loop
-subnqn:  blktests-subsystem-43
+subnqn:  blktests-subsystem-42
 =====Discovery Log Entry 44======
 trtype:  loop
-subnqn:  blktests-subsystem-44
+subnqn:  blktests-subsystem-43
 =====Discovery Log Entry 45======
 trtype:  loop
-subnqn:  blktests-subsystem-45
+subnqn:  blktests-subsystem-44
 =====Discovery Log Entry 46======
 trtype:  loop
-subnqn:  blktests-subsystem-46
+subnqn:  blktests-subsystem-45
 =====Discovery Log Entry 47======
 trtype:  loop
-subnqn:  blktests-subsystem-47
+subnqn:  blktests-subsystem-46
 =====Discovery Log Entry 48======
 trtype:  loop
-subnqn:  blktests-subsystem-48
+subnqn:  blktests-subsystem-47
 =====Discovery Log Entry 49======
 trtype:  loop
-subnqn:  blktests-subsystem-49
+subnqn:  blktests-subsystem-48
 =====Discovery Log Entry 50======
 trtype:  loop
-subnqn:  blktests-subsystem-50
+subnqn:  blktests-subsystem-49
 =====Discovery Log Entry 51======
 trtype:  loop
-subnqn:  blktests-subsystem-51
+subnqn:  blktests-subsystem-50
 =====Discovery Log Entry 52======
 trtype:  loop
-subnqn:  blktests-subsystem-52
+subnqn:  blktests-subsystem-51
 =====Discovery Log Entry 53======
 trtype:  loop
-subnqn:  blktests-subsystem-53
+subnqn:  blktests-subsystem-52
 =====Discovery Log Entry 54======
 trtype:  loop
-subnqn:  blktests-subsystem-54
+subnqn:  blktests-subsystem-53
 =====Discovery Log Entry 55======
 trtype:  loop
-subnqn:  blktests-subsystem-55
+subnqn:  blktests-subsystem-54
 =====Discovery Log Entry 56======
 trtype:  loop
-subnqn:  blktests-subsystem-56
+subnqn:  blktests-subsystem-55
 =====Discovery Log Entry 57======
 trtype:  loop
-subnqn:  blktests-subsystem-57
+subnqn:  blktests-subsystem-56
 =====Discovery Log Entry 58======
 trtype:  loop
-subnqn:  blktests-subsystem-58
+subnqn:  blktests-subsystem-57
 =====Discovery Log Entry 59======
 trtype:  loop
-subnqn:  blktests-subsystem-59
+subnqn:  blktests-subsystem-58
 =====Discovery Log Entry 60======
 trtype:  loop
-subnqn:  blktests-subsystem-60
+subnqn:  blktests-subsystem-59
 =====Discovery Log Entry 61======
 trtype:  loop
-subnqn:  blktests-subsystem-61
+subnqn:  blktests-subsystem-60
 =====Discovery Log Entry 62======
 trtype:  loop
-subnqn:  blktests-subsystem-62
+subnqn:  blktests-subsystem-61
 =====Discovery Log Entry 63======
 trtype:  loop
-subnqn:  blktests-subsystem-63
+subnqn:  blktests-subsystem-62
 =====Discovery Log Entry 64======
 trtype:  loop
-subnqn:  blktests-subsystem-64
+subnqn:  blktests-subsystem-63
 =====Discovery Log Entry 65======
 trtype:  loop
-subnqn:  blktests-subsystem-65
+subnqn:  blktests-subsystem-64
 =====Discovery Log Entry 66======
 trtype:  loop
-subnqn:  blktests-subsystem-66
+subnqn:  blktests-subsystem-65
 =====Discovery Log Entry 67======
 trtype:  loop
-subnqn:  blktests-subsystem-67
+subnqn:  blktests-subsystem-66
 =====Discovery Log Entry 68======
 trtype:  loop
-subnqn:  blktests-subsystem-68
+subnqn:  blktests-subsystem-67
 =====Discovery Log Entry 69======
 trtype:  loop
-subnqn:  blktests-subsystem-69
+subnqn:  blktests-subsystem-68
 =====Discovery Log Entry 70======
 trtype:  loop
-subnqn:  blktests-subsystem-70
+subnqn:  blktests-subsystem-69
 =====Discovery Log Entry 71======
 trtype:  loop
-subnqn:  blktests-subsystem-71
+subnqn:  blktests-subsystem-70
 =====Discovery Log Entry 72======
 trtype:  loop
-subnqn:  blktests-subsystem-72
+subnqn:  blktests-subsystem-71
 =====Discovery Log Entry 73======
 trtype:  loop
-subnqn:  blktests-subsystem-73
+subnqn:  blktests-subsystem-72
 =====Discovery Log Entry 74======
 trtype:  loop
-subnqn:  blktests-subsystem-74
+subnqn:  blktests-subsystem-73
 =====Discovery Log Entry 75======
 trtype:  loop
-subnqn:  blktests-subsystem-75
+subnqn:  blktests-subsystem-74
 =====Discovery Log Entry 76======
 trtype:  loop
-subnqn:  blktests-subsystem-76
+subnqn:  blktests-subsystem-75
 =====Discovery Log Entry 77======
 trtype:  loop
-subnqn:  blktests-subsystem-77
+subnqn:  blktests-subsystem-76
 =====Discovery Log Entry 78======
 trtype:  loop
-subnqn:  blktests-subsystem-78
+subnqn:  blktests-subsystem-77
 =====Discovery Log Entry 79======
 trtype:  loop
-subnqn:  blktests-subsystem-79
+subnqn:  blktests-subsystem-78
 =====Discovery Log Entry 80======
 trtype:  loop
-subnqn:  blktests-subsystem-80
+subnqn:  blktests-subsystem-79
 =====Discovery Log Entry 81======
 trtype:  loop
-subnqn:  blktests-subsystem-81
+subnqn:  blktests-subsystem-80
 =====Discovery Log Entry 82======
 trtype:  loop
-subnqn:  blktests-subsystem-82
+subnqn:  blktests-subsystem-81
 =====Discovery Log Entry 83======
 trtype:  loop
-subnqn:  blktests-subsystem-83
+subnqn:  blktests-subsystem-82
 =====Discovery Log Entry 84======
 trtype:  loop
-subnqn:  blktests-subsystem-84
+subnqn:  blktests-subsystem-83
 =====Discovery Log Entry 85======
 trtype:  loop
-subnqn:  blktests-subsystem-85
+subnqn:  blktests-subsystem-84
 =====Discovery Log Entry 86======
 trtype:  loop
-subnqn:  blktests-subsystem-86
+subnqn:  blktests-subsystem-85
 =====Discovery Log Entry 87======
 trtype:  loop
-subnqn:  blktests-subsystem-87
+subnqn:  blktests-subsystem-86
 =====Discovery Log Entry 88======
 trtype:  loop
-subnqn:  blktests-subsystem-88
+subnqn:  blktests-subsystem-87
 =====Discovery Log Entry 89======
 trtype:  loop
-subnqn:  blktests-subsystem-89
+subnqn:  blktests-subsystem-88
 =====Discovery Log Entry 90======
 trtype:  loop
-subnqn:  blktests-subsystem-90
+subnqn:  blktests-subsystem-89
 =====Discovery Log Entry 91======
 trtype:  loop
-subnqn:  blktests-subsystem-91
+subnqn:  blktests-subsystem-90
 =====Discovery Log Entry 92======
 trtype:  loop
-subnqn:  blktests-subsystem-92
+subnqn:  blktests-subsystem-91
 =====Discovery Log Entry 93======
 trtype:  loop
-subnqn:  blktests-subsystem-93
+subnqn:  blktests-subsystem-92
 =====Discovery Log Entry 94======
 trtype:  loop
-subnqn:  blktests-subsystem-94
+subnqn:  blktests-subsystem-93
 =====Discovery Log Entry 95======
 trtype:  loop
-subnqn:  blktests-subsystem-95
+subnqn:  blktests-subsystem-94
 =====Discovery Log Entry 96======
 trtype:  loop
-subnqn:  blktests-subsystem-96
+subnqn:  blktests-subsystem-95
 =====Discovery Log Entry 97======
 trtype:  loop
-subnqn:  blktests-subsystem-97
+subnqn:  blktests-subsystem-96
 =====Discovery Log Entry 98======
 trtype:  loop
-subnqn:  blktests-subsystem-98
+subnqn:  blktests-subsystem-97
 =====Discovery Log Entry 99======
 trtype:  loop
-subnqn:  blktests-subsystem-99
+subnqn:  blktests-subsystem-98
 =====Discovery Log Entry 100======
 trtype:  loop
-subnqn:  blktests-subsystem-100
+subnqn:  blktests-subsystem-99
 =====Discovery Log Entry 101======
 trtype:  loop
-subnqn:  blktests-subsystem-101
+subnqn:  blktests-subsystem-100
 =====Discovery Log Entry 102======
 trtype:  loop
-subnqn:  blktests-subsystem-102
+subnqn:  blktests-subsystem-101
 =====Discovery Log Entry 103======
 trtype:  loop
-subnqn:  blktests-subsystem-103
+subnqn:  blktests-subsystem-102
 =====Discovery Log Entry 104======
 trtype:  loop
-subnqn:  blktests-subsystem-104
+subnqn:  blktests-subsystem-103
 =====Discovery Log Entry 105======
 trtype:  loop
-subnqn:  blktests-subsystem-105
+subnqn:  blktests-subsystem-104
 =====Discovery Log Entry 106======
 trtype:  loop
-subnqn:  blktests-subsystem-106
+subnqn:  blktests-subsystem-105
 =====Discovery Log Entry 107======
 trtype:  loop
-subnqn:  blktests-subsystem-107
+subnqn:  blktests-subsystem-106
 =====Discovery Log Entry 108======
 trtype:  loop
-subnqn:  blktests-subsystem-108
+subnqn:  blktests-subsystem-107
 =====Discovery Log Entry 109======
 trtype:  loop
-subnqn:  blktests-subsystem-109
+subnqn:  blktests-subsystem-108
 =====Discovery Log Entry 110======
 trtype:  loop
-subnqn:  blktests-subsystem-110
+subnqn:  blktests-subsystem-109
 =====Discovery Log Entry 111======
 trtype:  loop
-subnqn:  blktests-subsystem-111
+subnqn:  blktests-subsystem-110
 =====Discovery Log Entry 112======
 trtype:  loop
-subnqn:  blktests-subsystem-112
+subnqn:  blktests-subsystem-111
 =====Discovery Log Entry 113======
 trtype:  loop
-subnqn:  blktests-subsystem-113
+subnqn:  blktests-subsystem-112
 =====Discovery Log Entry 114======
 trtype:  loop
-subnqn:  blktests-subsystem-114
+subnqn:  blktests-subsystem-113
 =====Discovery Log Entry 115======
 trtype:  loop
-subnqn:  blktests-subsystem-115
+subnqn:  blktests-subsystem-114
 =====Discovery Log Entry 116======
 trtype:  loop
-subnqn:  blktests-subsystem-116
+subnqn:  blktests-subsystem-115
 =====Discovery Log Entry 117======
 trtype:  loop
-subnqn:  blktests-subsystem-117
+subnqn:  blktests-subsystem-116
 =====Discovery Log Entry 118======
 trtype:  loop
-subnqn:  blktests-subsystem-118
+subnqn:  blktests-subsystem-117
 =====Discovery Log Entry 119======
 trtype:  loop
-subnqn:  blktests-subsystem-119
+subnqn:  blktests-subsystem-118
 =====Discovery Log Entry 120======
 trtype:  loop
-subnqn:  blktests-subsystem-120
+subnqn:  blktests-subsystem-119
 =====Discovery Log Entry 121======
 trtype:  loop
-subnqn:  blktests-subsystem-121
+subnqn:  blktests-subsystem-120
 =====Discovery Log Entry 122======
 trtype:  loop
-subnqn:  blktests-subsystem-122
+subnqn:  blktests-subsystem-121
 =====Discovery Log Entry 123======
 trtype:  loop
-subnqn:  blktests-subsystem-123
+subnqn:  blktests-subsystem-122
 =====Discovery Log Entry 124======
 trtype:  loop
-subnqn:  blktests-subsystem-124
+subnqn:  blktests-subsystem-123
 =====Discovery Log Entry 125======
 trtype:  loop
-subnqn:  blktests-subsystem-125
+subnqn:  blktests-subsystem-124
 =====Discovery Log Entry 126======
 trtype:  loop
-subnqn:  blktests-subsystem-126
+subnqn:  blktests-subsystem-125
 =====Discovery Log Entry 127======
 trtype:  loop
-subnqn:  blktests-subsystem-127
+subnqn:  blktests-subsystem-126
 =====Discovery Log Entry 128======
 trtype:  loop
-subnqn:  blktests-subsystem-128
+subnqn:  blktests-subsystem-127
 =====Discovery Log Entry 129======
 trtype:  loop
-subnqn:  blktests-subsystem-129
+subnqn:  blktests-subsystem-128
 =====Discovery Log Entry 130======
 trtype:  loop
-subnqn:  blktests-subsystem-130
+subnqn:  blktests-subsystem-129
 =====Discovery Log Entry 131======
 trtype:  loop
-subnqn:  blktests-subsystem-131
+subnqn:  blktests-subsystem-130
 =====Discovery Log Entry 132======
 trtype:  loop
-subnqn:  blktests-subsystem-132
+subnqn:  blktests-subsystem-131
 =====Discovery Log Entry 133======
 trtype:  loop
-subnqn:  blktests-subsystem-133
+subnqn:  blktests-subsystem-132
 =====Discovery Log Entry 134======
 trtype:  loop
-subnqn:  blktests-subsystem-134
+subnqn:  blktests-subsystem-133
 =====Discovery Log Entry 135======
 trtype:  loop
-subnqn:  blktests-subsystem-135
+subnqn:  blktests-subsystem-134
 =====Discovery Log Entry 136======
 trtype:  loop
-subnqn:  blktests-subsystem-136
+subnqn:  blktests-subsystem-135
 =====Discovery Log Entry 137======
 trtype:  loop
-subnqn:  blktests-subsystem-137
+subnqn:  blktests-subsystem-136
 =====Discovery Log Entry 138======
 trtype:  loop
-subnqn:  blktests-subsystem-138
+subnqn:  blktests-subsystem-137
 =====Discovery Log Entry 139======
 trtype:  loop
-subnqn:  blktests-subsystem-139
+subnqn:  blktests-subsystem-138
 =====Discovery Log Entry 140======
 trtype:  loop
-subnqn:  blktests-subsystem-140
+subnqn:  blktests-subsystem-139
 =====Discovery Log Entry 141======
 trtype:  loop
-subnqn:  blktests-subsystem-141
+subnqn:  blktests-subsystem-140
 =====Discovery Log Entry 142======
 trtype:  loop
-subnqn:  blktests-subsystem-142
+subnqn:  blktests-subsystem-141
 =====Discovery Log Entry 143======
 trtype:  loop
-subnqn:  blktests-subsystem-143
+subnqn:  blktests-subsystem-142
 =====Discovery Log Entry 144======
 trtype:  loop
-subnqn:  blktests-subsystem-144
+subnqn:  blktests-subsystem-143
 =====Discovery Log Entry 145======
 trtype:  loop
-subnqn:  blktests-subsystem-145
+subnqn:  blktests-subsystem-144
 =====Discovery Log Entry 146======
 trtype:  loop
-subnqn:  blktests-subsystem-146
+subnqn:  blktests-subsystem-145
 =====Discovery Log Entry 147======
 trtype:  loop
-subnqn:  blktests-subsystem-147
+subnqn:  blktests-subsystem-146
 =====Discovery Log Entry 148======
 trtype:  loop
-subnqn:  blktests-subsystem-148
+subnqn:  blktests-subsystem-147
 =====Discovery Log Entry 149======
 trtype:  loop
-subnqn:  blktests-subsystem-149
+subnqn:  blktests-subsystem-148
 =====Discovery Log Entry 150======
 trtype:  loop
-subnqn:  blktests-subsystem-150
+subnqn:  blktests-subsystem-149
 =====Discovery Log Entry 151======
 trtype:  loop
-subnqn:  blktests-subsystem-151
+subnqn:  blktests-subsystem-150
 =====Discovery Log Entry 152======
 trtype:  loop
-subnqn:  blktests-subsystem-152
+subnqn:  blktests-subsystem-151
 =====Discovery Log Entry 153======
 trtype:  loop
-subnqn:  blktests-subsystem-153
+subnqn:  blktests-subsystem-152
 =====Discovery Log Entry 154======
 trtype:  loop
-subnqn:  blktests-subsystem-154
+subnqn:  blktests-subsystem-153
 =====Discovery Log Entry 155======
 trtype:  loop
-subnqn:  blktests-subsystem-155
+subnqn:  blktests-subsystem-154
 =====Discovery Log Entry 156======
 trtype:  loop
-subnqn:  blktests-subsystem-156
+subnqn:  blktests-subsystem-155
 =====Discovery Log Entry 157======
 trtype:  loop
-subnqn:  blktests-subsystem-157
+subnqn:  blktests-subsystem-156
 =====Discovery Log Entry 158======
 trtype:  loop
-subnqn:  blktests-subsystem-158
+subnqn:  blktests-subsystem-157
 =====Discovery Log Entry 159======
 trtype:  loop
-subnqn:  blktests-subsystem-159
+subnqn:  blktests-subsystem-158
 =====Discovery Log Entry 160======
 trtype:  loop
-subnqn:  blktests-subsystem-160
+subnqn:  blktests-subsystem-159
 =====Discovery Log Entry 161======
 trtype:  loop
-subnqn:  blktests-subsystem-161
+subnqn:  blktests-subsystem-160
 =====Discovery Log Entry 162======
 trtype:  loop
-subnqn:  blktests-subsystem-162
+subnqn:  blktests-subsystem-161
 =====Discovery Log Entry 163======
 trtype:  loop
-subnqn:  blktests-subsystem-163
+subnqn:  blktests-subsystem-162
 =====Discovery Log Entry 164======
 trtype:  loop
-subnqn:  blktests-subsystem-164
+subnqn:  blktests-subsystem-163
 =====Discovery Log Entry 165======
 trtype:  loop
-subnqn:  blktests-subsystem-165
+subnqn:  blktests-subsystem-164
 =====Discovery Log Entry 166======
 trtype:  loop
-subnqn:  blktests-subsystem-166
+subnqn:  blktests-subsystem-165
 =====Discovery Log Entry 167======
 trtype:  loop
-subnqn:  blktests-subsystem-167
+subnqn:  blktests-subsystem-166
 =====Discovery Log Entry 168======
 trtype:  loop
-subnqn:  blktests-subsystem-168
+subnqn:  blktests-subsystem-167
 =====Discovery Log Entry 169======
 trtype:  loop
-subnqn:  blktests-subsystem-169
+subnqn:  blktests-subsystem-168
 =====Discovery Log Entry 170======
 trtype:  loop
-subnqn:  blktests-subsystem-170
+subnqn:  blktests-subsystem-169
 =====Discovery Log Entry 171======
 trtype:  loop
-subnqn:  blktests-subsystem-171
+subnqn:  blktests-subsystem-170
 =====Discovery Log Entry 172======
 trtype:  loop
-subnqn:  blktests-subsystem-172
+subnqn:  blktests-subsystem-171
 =====Discovery Log Entry 173======
 trtype:  loop
-subnqn:  blktests-subsystem-173
+subnqn:  blktests-subsystem-172
 =====Discovery Log Entry 174======
 trtype:  loop
-subnqn:  blktests-subsystem-174
+subnqn:  blktests-subsystem-173
 =====Discovery Log Entry 175======
 trtype:  loop
-subnqn:  blktests-subsystem-175
+subnqn:  blktests-subsystem-174
 =====Discovery Log Entry 176======
 trtype:  loop
-subnqn:  blktests-subsystem-176
+subnqn:  blktests-subsystem-175
 =====Discovery Log Entry 177======
 trtype:  loop
-subnqn:  blktests-subsystem-177
+subnqn:  blktests-subsystem-176
 =====Discovery Log Entry 178======
 trtype:  loop
-subnqn:  blktests-subsystem-178
+subnqn:  blktests-subsystem-177
 =====Discovery Log Entry 179======
 trtype:  loop
-subnqn:  blktests-subsystem-179
+subnqn:  blktests-subsystem-178
 =====Discovery Log Entry 180======
 trtype:  loop
-subnqn:  blktests-subsystem-180
+subnqn:  blktests-subsystem-179
 =====Discovery Log Entry 181======
 trtype:  loop
-subnqn:  blktests-subsystem-181
+subnqn:  blktests-subsystem-180
 =====Discovery Log Entry 182======
 trtype:  loop
-subnqn:  blktests-subsystem-182
+subnqn:  blktests-subsystem-181
 =====Discovery Log Entry 183======
 trtype:  loop
-subnqn:  blktests-subsystem-183
+subnqn:  blktests-subsystem-182
 =====Discovery Log Entry 184======
 trtype:  loop
-subnqn:  blktests-subsystem-184
+subnqn:  blktests-subsystem-183
 =====Discovery Log Entry 185======
 trtype:  loop
-subnqn:  blktests-subsystem-185
+subnqn:  blktests-subsystem-184
 =====Discovery Log Entry 186======
 trtype:  loop
-subnqn:  blktests-subsystem-186
+subnqn:  blktests-subsystem-185
 =====Discovery Log Entry 187======
 trtype:  loop
-subnqn:  blktests-subsystem-187
+subnqn:  blktests-subsystem-186
 =====Discovery Log Entry 188======
 trtype:  loop
-subnqn:  blktests-subsystem-188
+subnqn:  blktests-subsystem-187
 =====Discovery Log Entry 189======
 trtype:  loop
-subnqn:  blktests-subsystem-189
+subnqn:  blktests-subsystem-188
 =====Discovery Log Entry 190======
 trtype:  loop
-subnqn:  blktests-subsystem-190
+subnqn:  blktests-subsystem-189
 =====Discovery Log Entry 191======
 trtype:  loop
-subnqn:  blktests-subsystem-191
+subnqn:  blktests-subsystem-190
 =====Discovery Log Entry 192======
 trtype:  loop
-subnqn:  blktests-subsystem-192
+subnqn:  blktests-subsystem-191
 =====Discovery Log Entry 193======
 trtype:  loop
-subnqn:  blktests-subsystem-193
+subnqn:  blktests-subsystem-192
 =====Discovery Log Entry 194======
 trtype:  loop
-subnqn:  blktests-subsystem-194
+subnqn:  blktests-subsystem-193
 =====Discovery Log Entry 195======
 trtype:  loop
-subnqn:  blktests-subsystem-195
+subnqn:  blktests-subsystem-194
 =====Discovery Log Entry 196======
 trtype:  loop
-subnqn:  blktests-subsystem-196
+subnqn:  blktests-subsystem-195
 =====Discovery Log Entry 197======
 trtype:  loop
-subnqn:  blktests-subsystem-197
+subnqn:  blktests-subsystem-196
 =====Discovery Log Entry 198======
 trtype:  loop
-subnqn:  blktests-subsystem-198
+subnqn:  blktests-subsystem-197
 =====Discovery Log Entry 199======
 trtype:  loop
-subnqn:  blktests-subsystem-199
+subnqn:  blktests-subsystem-198
 =====Discovery Log Entry 200======
 trtype:  loop
-subnqn:  blktests-subsystem-200
+subnqn:  blktests-subsystem-199
 =====Discovery Log Entry 201======
 trtype:  loop
-subnqn:  blktests-subsystem-201
+subnqn:  blktests-subsystem-200
 =====Discovery Log Entry 202======
 trtype:  loop
-subnqn:  blktests-subsystem-202
+subnqn:  blktests-subsystem-201
 =====Discovery Log Entry 203======
 trtype:  loop
-subnqn:  blktests-subsystem-203
+subnqn:  blktests-subsystem-202
 =====Discovery Log Entry 204======
 trtype:  loop
-subnqn:  blktests-subsystem-204
+subnqn:  blktests-subsystem-203
 =====Discovery Log Entry 205======
 trtype:  loop
-subnqn:  blktests-subsystem-205
+subnqn:  blktests-subsystem-204
 =====Discovery Log Entry 206======
 trtype:  loop
-subnqn:  blktests-subsystem-206
+subnqn:  blktests-subsystem-205
 =====Discovery Log Entry 207======
 trtype:  loop
-subnqn:  blktests-subsystem-207
+subnqn:  blktests-subsystem-206
 =====Discovery Log Entry 208======
 trtype:  loop
-subnqn:  blktests-subsystem-208
+subnqn:  blktests-subsystem-207
 =====Discovery Log Entry 209======
 trtype:  loop
-subnqn:  blktests-subsystem-209
+subnqn:  blktests-subsystem-208
 =====Discovery Log Entry 210======
 trtype:  loop
-subnqn:  blktests-subsystem-210
+subnqn:  blktests-subsystem-209
 =====Discovery Log Entry 211======
 trtype:  loop
-subnqn:  blktests-subsystem-211
+subnqn:  blktests-subsystem-210
 =====Discovery Log Entry 212======
 trtype:  loop
-subnqn:  blktests-subsystem-212
+subnqn:  blktests-subsystem-211
 =====Discovery Log Entry 213======
 trtype:  loop
-subnqn:  blktests-subsystem-213
+subnqn:  blktests-subsystem-212
 =====Discovery Log Entry 214======
 trtype:  loop
-subnqn:  blktests-subsystem-214
+subnqn:  blktests-subsystem-213
 =====Discovery Log Entry 215======
 trtype:  loop
-subnqn:  blktests-subsystem-215
+subnqn:  blktests-subsystem-214
 =====Discovery Log Entry 216======
 trtype:  loop
-subnqn:  blktests-subsystem-216
+subnqn:  blktests-subsystem-215
 =====Discovery Log Entry 217======
 trtype:  loop
-subnqn:  blktests-subsystem-217
+subnqn:  blktests-subsystem-216
 =====Discovery Log Entry 218======
 trtype:  loop
-subnqn:  blktests-subsystem-218
+subnqn:  blktests-subsystem-217
 =====Discovery Log Entry 219======
 trtype:  loop
-subnqn:  blktests-subsystem-219
+subnqn:  blktests-subsystem-218
 =====Discovery Log Entry 220======
 trtype:  loop
-subnqn:  blktests-subsystem-220
+subnqn:  blktests-subsystem-219
 =====Discovery Log Entry 221======
 trtype:  loop
-subnqn:  blktests-subsystem-221
+subnqn:  blktests-subsystem-220
 =====Discovery Log Entry 222======
 trtype:  loop
-subnqn:  blktests-subsystem-222
+subnqn:  blktests-subsystem-221
 =====Discovery Log Entry 223======
 trtype:  loop
-subnqn:  blktests-subsystem-223
+subnqn:  blktests-subsystem-222
 =====Discovery Log Entry 224======
 trtype:  loop
-subnqn:  blktests-subsystem-224
+subnqn:  blktests-subsystem-223
 =====Discovery Log Entry 225======
 trtype:  loop
-subnqn:  blktests-subsystem-225
+subnqn:  blktests-subsystem-224
 =====Discovery Log Entry 226======
 trtype:  loop
-subnqn:  blktests-subsystem-226
+subnqn:  blktests-subsystem-225
 =====Discovery Log Entry 227======
 trtype:  loop
-subnqn:  blktests-subsystem-227
+subnqn:  blktests-subsystem-226
 =====Discovery Log Entry 228======
 trtype:  loop
-subnqn:  blktests-subsystem-228
+subnqn:  blktests-subsystem-227
 =====Discovery Log Entry 229======
 trtype:  loop
-subnqn:  blktests-subsystem-229
+subnqn:  blktests-subsystem-228
 =====Discovery Log Entry 230======
 trtype:  loop
-subnqn:  blktests-subsystem-230
+subnqn:  blktests-subsystem-229
 =====Discovery Log Entry 231======
 trtype:  loop
-subnqn:  blktests-subsystem-231
+subnqn:  blktests-subsystem-230
 =====Discovery Log Entry 232======
 trtype:  loop
-subnqn:  blktests-subsystem-232
+subnqn:  blktests-subsystem-231
 =====Discovery Log Entry 233======
 trtype:  loop
-subnqn:  blktests-subsystem-233
+subnqn:  blktests-subsystem-232
 =====Discovery Log Entry 234======
 trtype:  loop
-subnqn:  blktests-subsystem-234
+subnqn:  blktests-subsystem-233
 =====Discovery Log Entry 235======
 trtype:  loop
-subnqn:  blktests-subsystem-235
+subnqn:  blktests-subsystem-234
 =====Discovery Log Entry 236======
 trtype:  loop
-subnqn:  blktests-subsystem-236
+subnqn:  blktests-subsystem-235
 =====Discovery Log Entry 237======
 trtype:  loop
-subnqn:  blktests-subsystem-237
+subnqn:  blktests-subsystem-236
 =====Discovery Log Entry 238======
 trtype:  loop
-subnqn:  blktests-subsystem-238
+subnqn:  blktests-subsystem-237
 =====Discovery Log Entry 239======
 trtype:  loop
-subnqn:  blktests-subsystem-239
+subnqn:  blktests-subsystem-238
 =====Discovery Log Entry 240======
 trtype:  loop
-subnqn:  blktests-subsystem-240
+subnqn:  blktests-subsystem-239
 =====Discovery Log Entry 241======
 trtype:  loop
-subnqn:  blktests-subsystem-241
+subnqn:  blktests-subsystem-240
 =====Discovery Log Entry 242======
 trtype:  loop
-subnqn:  blktests-subsystem-242
+subnqn:  blktests-subsystem-241
 =====Discovery Log Entry 243======
 trtype:  loop
-subnqn:  blktests-subsystem-243
+subnqn:  blktests-subsystem-242
 =====Discovery Log Entry 244======
 trtype:  loop
-subnqn:  blktests-subsystem-244
+subnqn:  blktests-subsystem-243
 =====Discovery Log Entry 245======
 trtype:  loop
-subnqn:  blktests-subsystem-245
+subnqn:  blktests-subsystem-244
 =====Discovery Log Entry 246======
 trtype:  loop
-subnqn:  blktests-subsystem-246
+subnqn:  blktests-subsystem-245
 =====Discovery Log Entry 247======
 trtype:  loop
-subnqn:  blktests-subsystem-247
+subnqn:  blktests-subsystem-246
 =====Discovery Log Entry 248======
 trtype:  loop
-subnqn:  blktests-subsystem-248
+subnqn:  blktests-subsystem-247
 =====Discovery Log Entry 249======
 trtype:  loop
-subnqn:  blktests-subsystem-249
+subnqn:  blktests-subsystem-248
 =====Discovery Log Entry 250======
 trtype:  loop
-subnqn:  blktests-subsystem-250
+subnqn:  blktests-subsystem-249
 =====Discovery Log Entry 251======
 trtype:  loop
-subnqn:  blktests-subsystem-251
+subnqn:  blktests-subsystem-250
 =====Discovery Log Entry 252======
 trtype:  loop
-subnqn:  blktests-subsystem-252
+subnqn:  blktests-subsystem-251
 =====Discovery Log Entry 253======
 trtype:  loop
-subnqn:  blktests-subsystem-253
+subnqn:  blktests-subsystem-252
 =====Discovery Log Entry 254======
 trtype:  loop
-subnqn:  blktests-subsystem-254
+subnqn:  blktests-subsystem-253
 =====Discovery Log Entry 255======
 trtype:  loop
-subnqn:  blktests-subsystem-255
+subnqn:  blktests-subsystem-254
 =====Discovery Log Entry 256======
 trtype:  loop
-subnqn:  blktests-subsystem-256
+subnqn:  blktests-subsystem-255
 =====Discovery Log Entry 257======
 trtype:  loop
-subnqn:  blktests-subsystem-257
+subnqn:  blktests-subsystem-256
 =====Discovery Log Entry 258======
 trtype:  loop
-subnqn:  blktests-subsystem-258
+subnqn:  blktests-subsystem-257
 =====Discovery Log Entry 259======
 trtype:  loop
-subnqn:  blktests-subsystem-259
+subnqn:  blktests-subsystem-258
 =====Discovery Log Entry 260======
 trtype:  loop
-subnqn:  blktests-subsystem-260
+subnqn:  blktests-subsystem-259
 =====Discovery Log Entry 261======
 trtype:  loop
-subnqn:  blktests-subsystem-261
+subnqn:  blktests-subsystem-260
 =====Discovery Log Entry 262======
 trtype:  loop
-subnqn:  blktests-subsystem-262
+subnqn:  blktests-subsystem-261
 =====Discovery Log Entry 263======
 trtype:  loop
-subnqn:  blktests-subsystem-263
+subnqn:  blktests-subsystem-262
 =====Discovery Log Entry 264======
 trtype:  loop
-subnqn:  blktests-subsystem-264
+subnqn:  blktests-subsystem-263
 =====Discovery Log Entry 265======
 trtype:  loop
-subnqn:  blktests-subsystem-265
+subnqn:  blktests-subsystem-264
 =====Discovery Log Entry 266======
 trtype:  loop
-subnqn:  blktests-subsystem-266
+subnqn:  blktests-subsystem-265
 =====Discovery Log Entry 267======
 trtype:  loop
-subnqn:  blktests-subsystem-267
+subnqn:  blktests-subsystem-266
 =====Discovery Log Entry 268======
 trtype:  loop
-subnqn:  blktests-subsystem-268
+subnqn:  blktests-subsystem-267
 =====Discovery Log Entry 269======
 trtype:  loop
-subnqn:  blktests-subsystem-269
+subnqn:  blktests-subsystem-268
 =====Discovery Log Entry 270======
 trtype:  loop
-subnqn:  blktests-subsystem-270
+subnqn:  blktests-subsystem-269
 =====Discovery Log Entry 271======
 trtype:  loop
-subnqn:  blktests-subsystem-271
+subnqn:  blktests-subsystem-270
 =====Discovery Log Entry 272======
 trtype:  loop
-subnqn:  blktests-subsystem-272
+subnqn:  blktests-subsystem-271
 =====Discovery Log Entry 273======
 trtype:  loop
-subnqn:  blktests-subsystem-273
+subnqn:  blktests-subsystem-272
 =====Discovery Log Entry 274======
 trtype:  loop
-subnqn:  blktests-subsystem-274
+subnqn:  blktests-subsystem-273
 =====Discovery Log Entry 275======
 trtype:  loop
-subnqn:  blktests-subsystem-275
+subnqn:  blktests-subsystem-274
 =====Discovery Log Entry 276======
 trtype:  loop
-subnqn:  blktests-subsystem-276
+subnqn:  blktests-subsystem-275
 =====Discovery Log Entry 277======
 trtype:  loop
-subnqn:  blktests-subsystem-277
+subnqn:  blktests-subsystem-276
 =====Discovery Log Entry 278======
 trtype:  loop
-subnqn:  blktests-subsystem-278
+subnqn:  blktests-subsystem-277
 =====Discovery Log Entry 279======
 trtype:  loop
-subnqn:  blktests-subsystem-279
+subnqn:  blktests-subsystem-278
 =====Discovery Log Entry 280======
 trtype:  loop
-subnqn:  blktests-subsystem-280
+subnqn:  blktests-subsystem-279
 =====Discovery Log Entry 281======
 trtype:  loop
-subnqn:  blktests-subsystem-281
+subnqn:  blktests-subsystem-280
 =====Discovery Log Entry 282======
 trtype:  loop
-subnqn:  blktests-subsystem-282
+subnqn:  blktests-subsystem-281
 =====Discovery Log Entry 283======
 trtype:  loop
-subnqn:  blktests-subsystem-283
+subnqn:  blktests-subsystem-282
 =====Discovery Log Entry 284======
 trtype:  loop
-subnqn:  blktests-subsystem-284
+subnqn:  blktests-subsystem-283
 =====Discovery Log Entry 285======
 trtype:  loop
-subnqn:  blktests-subsystem-285
+subnqn:  blktests-subsystem-284
 =====Discovery Log Entry 286======
 trtype:  loop
-subnqn:  blktests-subsystem-286
+subnqn:  blktests-subsystem-285
 =====Discovery Log Entry 287======
 trtype:  loop
-subnqn:  blktests-subsystem-287
+subnqn:  blktests-subsystem-286
 =====Discovery Log Entry 288======
 trtype:  loop
-subnqn:  blktests-subsystem-288
+subnqn:  blktests-subsystem-287
 =====Discovery Log Entry 289======
 trtype:  loop
-subnqn:  blktests-subsystem-289
+subnqn:  blktests-subsystem-288
 =====Discovery Log Entry 290======
 trtype:  loop
-subnqn:  blktests-subsystem-290
+subnqn:  blktests-subsystem-289
 =====Discovery Log Entry 291======
 trtype:  loop
-subnqn:  blktests-subsystem-291
+subnqn:  blktests-subsystem-290
 =====Discovery Log Entry 292======
 trtype:  loop
-subnqn:  blktests-subsystem-292
+subnqn:  blktests-subsystem-291
 =====Discovery Log Entry 293======
 trtype:  loop
-subnqn:  blktests-subsystem-293
+subnqn:  blktests-subsystem-292
 =====Discovery Log Entry 294======
 trtype:  loop
-subnqn:  blktests-subsystem-294
+subnqn:  blktests-subsystem-293
 =====Discovery Log Entry 295======
 trtype:  loop
-subnqn:  blktests-subsystem-295
+subnqn:  blktests-subsystem-294
 =====Discovery Log Entry 296======
 trtype:  loop
-subnqn:  blktests-subsystem-296
+subnqn:  blktests-subsystem-295
 =====Discovery Log Entry 297======
 trtype:  loop
-subnqn:  blktests-subsystem-297
+subnqn:  blktests-subsystem-296
 =====Discovery Log Entry 298======
 trtype:  loop
-subnqn:  blktests-subsystem-298
+subnqn:  blktests-subsystem-297
 =====Discovery Log Entry 299======
 trtype:  loop
-subnqn:  blktests-subsystem-299
+subnqn:  blktests-subsystem-298
 =====Discovery Log Entry 300======
 trtype:  loop
-subnqn:  blktests-subsystem-300
+subnqn:  blktests-subsystem-299
 =====Discovery Log Entry 301======
 trtype:  loop
-subnqn:  blktests-subsystem-301
+subnqn:  blktests-subsystem-300
 =====Discovery Log Entry 302======
 trtype:  loop
-subnqn:  blktests-subsystem-302
+subnqn:  blktests-subsystem-301
 =====Discovery Log Entry 303======
 trtype:  loop
-subnqn:  blktests-subsystem-303
+subnqn:  blktests-subsystem-302
 =====Discovery Log Entry 304======
 trtype:  loop
-subnqn:  blktests-subsystem-304
+subnqn:  blktests-subsystem-303
 =====Discovery Log Entry 305======
 trtype:  loop
-subnqn:  blktests-subsystem-305
+subnqn:  blktests-subsystem-304
 =====Discovery Log Entry 306======
 trtype:  loop
-subnqn:  blktests-subsystem-306
+subnqn:  blktests-subsystem-305
 =====Discovery Log Entry 307======
 trtype:  loop
-subnqn:  blktests-subsystem-307
+subnqn:  blktests-subsystem-306
 =====Discovery Log Entry 308======
 trtype:  loop
-subnqn:  blktests-subsystem-308
+subnqn:  blktests-subsystem-307
 =====Discovery Log Entry 309======
 trtype:  loop
-subnqn:  blktests-subsystem-309
+subnqn:  blktests-subsystem-308
 =====Discovery Log Entry 310======
 trtype:  loop
-subnqn:  blktests-subsystem-310
+subnqn:  blktests-subsystem-309
 =====Discovery Log Entry 311======
 trtype:  loop
-subnqn:  blktests-subsystem-311
+subnqn:  blktests-subsystem-310
 =====Discovery Log Entry 312======
 trtype:  loop
-subnqn:  blktests-subsystem-312
+subnqn:  blktests-subsystem-311
 =====Discovery Log Entry 313======
 trtype:  loop
-subnqn:  blktests-subsystem-313
+subnqn:  blktests-subsystem-312
 =====Discovery Log Entry 314======
 trtype:  loop
-subnqn:  blktests-subsystem-314
+subnqn:  blktests-subsystem-313
 =====Discovery Log Entry 315======
 trtype:  loop
-subnqn:  blktests-subsystem-315
+subnqn:  blktests-subsystem-314
 =====Discovery Log Entry 316======
 trtype:  loop
-subnqn:  blktests-subsystem-316
+subnqn:  blktests-subsystem-315
 =====Discovery Log Entry 317======
 trtype:  loop
-subnqn:  blktests-subsystem-317
+subnqn:  blktests-subsystem-316
 =====Discovery Log Entry 318======
 trtype:  loop
-subnqn:  blktests-subsystem-318
+subnqn:  blktests-subsystem-317
 =====Discovery Log Entry 319======
 trtype:  loop
-subnqn:  blktests-subsystem-319
+subnqn:  blktests-subsystem-318
 =====Discovery Log Entry 320======
 trtype:  loop
-subnqn:  blktests-subsystem-320
+subnqn:  blktests-subsystem-319
 =====Discovery Log Entry 321======
 trtype:  loop
-subnqn:  blktests-subsystem-321
+subnqn:  blktests-subsystem-320
 =====Discovery Log Entry 322======
 trtype:  loop
-subnqn:  blktests-subsystem-322
+subnqn:  blktests-subsystem-321
 =====Discovery Log Entry 323======
 trtype:  loop
-subnqn:  blktests-subsystem-323
+subnqn:  blktests-subsystem-322
 =====Discovery Log Entry 324======
 trtype:  loop
-subnqn:  blktests-subsystem-324
+subnqn:  blktests-subsystem-323
 =====Discovery Log Entry 325======
 trtype:  loop
-subnqn:  blktests-subsystem-325
+subnqn:  blktests-subsystem-324
 =====Discovery Log Entry 326======
 trtype:  loop
-subnqn:  blktests-subsystem-326
+subnqn:  blktests-subsystem-325
 =====Discovery Log Entry 327======
 trtype:  loop
-subnqn:  blktests-subsystem-327
+subnqn:  blktests-subsystem-326
 =====Discovery Log Entry 328======
 trtype:  loop
-subnqn:  blktests-subsystem-328
+subnqn:  blktests-subsystem-327
 =====Discovery Log Entry 329======
 trtype:  loop
-subnqn:  blktests-subsystem-329
+subnqn:  blktests-subsystem-328
 =====Discovery Log Entry 330======
 trtype:  loop
-subnqn:  blktests-subsystem-330
+subnqn:  blktests-subsystem-329
 =====Discovery Log Entry 331======
 trtype:  loop
-subnqn:  blktests-subsystem-331
+subnqn:  blktests-subsystem-330
 =====Discovery Log Entry 332======
 trtype:  loop
-subnqn:  blktests-subsystem-332
+subnqn:  blktests-subsystem-331
 =====Discovery Log Entry 333======
 trtype:  loop
-subnqn:  blktests-subsystem-333
+subnqn:  blktests-subsystem-332
 =====Discovery Log Entry 334======
 trtype:  loop
-subnqn:  blktests-subsystem-334
+subnqn:  blktests-subsystem-333
 =====Discovery Log Entry 335======
 trtype:  loop
-subnqn:  blktests-subsystem-335
+subnqn:  blktests-subsystem-334
 =====Discovery Log Entry 336======
 trtype:  loop
-subnqn:  blktests-subsystem-336
+subnqn:  blktests-subsystem-335
 =====Discovery Log Entry 337======
 trtype:  loop
-subnqn:  blktests-subsystem-337
+subnqn:  blktests-subsystem-336
 =====Discovery Log Entry 338======
 trtype:  loop
-subnqn:  blktests-subsystem-338
+subnqn:  blktests-subsystem-337
 =====Discovery Log Entry 339======
 trtype:  loop
-subnqn:  blktests-subsystem-339
+subnqn:  blktests-subsystem-338
 =====Discovery Log Entry 340======
 trtype:  loop
-subnqn:  blktests-subsystem-340
+subnqn:  blktests-subsystem-339
 =====Discovery Log Entry 341======
 trtype:  loop
-subnqn:  blktests-subsystem-341
+subnqn:  blktests-subsystem-340
 =====Discovery Log Entry 342======
 trtype:  loop
-subnqn:  blktests-subsystem-342
+subnqn:  blktests-subsystem-341
 =====Discovery Log Entry 343======
 trtype:  loop
-subnqn:  blktests-subsystem-343
+subnqn:  blktests-subsystem-342
 =====Discovery Log Entry 344======
 trtype:  loop
-subnqn:  blktests-subsystem-344
+subnqn:  blktests-subsystem-343
 =====Discovery Log Entry 345======
 trtype:  loop
-subnqn:  blktests-subsystem-345
+subnqn:  blktests-subsystem-344
 =====Discovery Log Entry 346======
 trtype:  loop
-subnqn:  blktests-subsystem-346
+subnqn:  blktests-subsystem-345
 =====Discovery Log Entry 347======
 trtype:  loop
-subnqn:  blktests-subsystem-347
+subnqn:  blktests-subsystem-346
 =====Discovery Log Entry 348======
 trtype:  loop
-subnqn:  blktests-subsystem-348
+subnqn:  blktests-subsystem-347
 =====Discovery Log Entry 349======
 trtype:  loop
-subnqn:  blktests-subsystem-349
+subnqn:  blktests-subsystem-348
 =====Discovery Log Entry 350======
 trtype:  loop
-subnqn:  blktests-subsystem-350
+subnqn:  blktests-subsystem-349
 =====Discovery Log Entry 351======
 trtype:  loop
-subnqn:  blktests-subsystem-351
+subnqn:  blktests-subsystem-350
 =====Discovery Log Entry 352======
 trtype:  loop
-subnqn:  blktests-subsystem-352
+subnqn:  blktests-subsystem-351
 =====Discovery Log Entry 353======
 trtype:  loop
-subnqn:  blktests-subsystem-353
+subnqn:  blktests-subsystem-352
 =====Discovery Log Entry 354======
 trtype:  loop
-subnqn:  blktests-subsystem-354
+subnqn:  blktests-subsystem-353
 =====Discovery Log Entry 355======
 trtype:  loop
-subnqn:  blktests-subsystem-355
+subnqn:  blktests-subsystem-354
 =====Discovery Log Entry 356======
 trtype:  loop
-subnqn:  blktests-subsystem-356
+subnqn:  blktests-subsystem-355
 =====Discovery Log Entry 357======
 trtype:  loop
-subnqn:  blktests-subsystem-357
+subnqn:  blktests-subsystem-356
 =====Discovery Log Entry 358======
 trtype:  loop
-subnqn:  blktests-subsystem-358
+subnqn:  blktests-subsystem-357
 =====Discovery Log Entry 359======
 trtype:  loop
-subnqn:  blktests-subsystem-359
+subnqn:  blktests-subsystem-358
 =====Discovery Log Entry 360======
 trtype:  loop
-subnqn:  blktests-subsystem-360
+subnqn:  blktests-subsystem-359
 =====Discovery Log Entry 361======
 trtype:  loop
-subnqn:  blktests-subsystem-361
+subnqn:  blktests-subsystem-360
 =====Discovery Log Entry 362======
 trtype:  loop
-subnqn:  blktests-subsystem-362
+subnqn:  blktests-subsystem-361
 =====Discovery Log Entry 363======
 trtype:  loop
-subnqn:  blktests-subsystem-363
+subnqn:  blktests-subsystem-362
 =====Discovery Log Entry 364======
 trtype:  loop
-subnqn:  blktests-subsystem-364
+subnqn:  blktests-subsystem-363
 =====Discovery Log Entry 365======
 trtype:  loop
-subnqn:  blktests-subsystem-365
+subnqn:  blktests-subsystem-364
 =====Discovery Log Entry 366======
 trtype:  loop
-subnqn:  blktests-subsystem-366
+subnqn:  blktests-subsystem-365
 =====Discovery Log Entry 367======
 trtype:  loop
-subnqn:  blktests-subsystem-367
+subnqn:  blktests-subsystem-366
 =====Discovery Log Entry 368======
 trtype:  loop
-subnqn:  blktests-subsystem-368
+subnqn:  blktests-subsystem-367
 =====Discovery Log Entry 369======
 trtype:  loop
-subnqn:  blktests-subsystem-369
+subnqn:  blktests-subsystem-368
 =====Discovery Log Entry 370======
 trtype:  loop
-subnqn:  blktests-subsystem-370
+subnqn:  blktests-subsystem-369
 =====Discovery Log Entry 371======
 trtype:  loop
-subnqn:  blktests-subsystem-371
+subnqn:  blktests-subsystem-370
 =====Discovery Log Entry 372======
 trtype:  loop
-subnqn:  blktests-subsystem-372
+subnqn:  blktests-subsystem-371
 =====Discovery Log Entry 373======
 trtype:  loop
-subnqn:  blktests-subsystem-373
+subnqn:  blktests-subsystem-372
 =====Discovery Log Entry 374======
 trtype:  loop
-subnqn:  blktests-subsystem-374
+subnqn:  blktests-subsystem-373
 =====Discovery Log Entry 375======
 trtype:  loop
-subnqn:  blktests-subsystem-375
+subnqn:  blktests-subsystem-374
 =====Discovery Log Entry 376======
 trtype:  loop
-subnqn:  blktests-subsystem-376
+subnqn:  blktests-subsystem-375
 =====Discovery Log Entry 377======
 trtype:  loop
-subnqn:  blktests-subsystem-377
+subnqn:  blktests-subsystem-376
 =====Discovery Log Entry 378======
 trtype:  loop
-subnqn:  blktests-subsystem-378
+subnqn:  blktests-subsystem-377
 =====Discovery Log Entry 379======
 trtype:  loop
-subnqn:  blktests-subsystem-379
+subnqn:  blktests-subsystem-378
 =====Discovery Log Entry 380======
 trtype:  loop
-subnqn:  blktests-subsystem-380
+subnqn:  blktests-subsystem-379
 =====Discovery Log Entry 381======
 trtype:  loop
-subnqn:  blktests-subsystem-381
+subnqn:  blktests-subsystem-380
 =====Discovery Log Entry 382======
 trtype:  loop
-subnqn:  blktests-subsystem-382
+subnqn:  blktests-subsystem-381
 =====Discovery Log Entry 383======
 trtype:  loop
-subnqn:  blktests-subsystem-383
+subnqn:  blktests-subsystem-382
 =====Discovery Log Entry 384======
 trtype:  loop
-subnqn:  blktests-subsystem-384
+subnqn:  blktests-subsystem-383
 =====Discovery Log Entry 385======
 trtype:  loop
-subnqn:  blktests-subsystem-385
+subnqn:  blktests-subsystem-384
 =====Discovery Log Entry 386======
 trtype:  loop
-subnqn:  blktests-subsystem-386
+subnqn:  blktests-subsystem-385
 =====Discovery Log Entry 387======
 trtype:  loop
-subnqn:  blktests-subsystem-387
+subnqn:  blktests-subsystem-386
 =====Discovery Log Entry 388======
 trtype:  loop
-subnqn:  blktests-subsystem-388
+subnqn:  blktests-subsystem-387
 =====Discovery Log Entry 389======
 trtype:  loop
-subnqn:  blktests-subsystem-389
+subnqn:  blktests-subsystem-388
 =====Discovery Log Entry 390======
 trtype:  loop
-subnqn:  blktests-subsystem-390
+subnqn:  blktests-subsystem-389
 =====Discovery Log Entry 391======
 trtype:  loop
-subnqn:  blktests-subsystem-391
+subnqn:  blktests-subsystem-390
 =====Discovery Log Entry 392======
 trtype:  loop
-subnqn:  blktests-subsystem-392
+subnqn:  blktests-subsystem-391
 =====Discovery Log Entry 393======
 trtype:  loop
-subnqn:  blktests-subsystem-393
+subnqn:  blktests-subsystem-392
 =====Discovery Log Entry 394======
 trtype:  loop
-subnqn:  blktests-subsystem-394
+subnqn:  blktests-subsystem-393
 =====Discovery Log Entry 395======
 trtype:  loop
-subnqn:  blktests-subsystem-395
+subnqn:  blktests-subsystem-394
 =====Discovery Log Entry 396======
 trtype:  loop
-subnqn:  blktests-subsystem-396
+subnqn:  blktests-subsystem-395
 =====Discovery Log Entry 397======
 trtype:  loop
-subnqn:  blktests-subsystem-397
+subnqn:  blktests-subsystem-396
 =====Discovery Log Entry 398======
 trtype:  loop
-subnqn:  blktests-subsystem-398
+subnqn:  blktests-subsystem-397
 =====Discovery Log Entry 399======
 trtype:  loop
-subnqn:  blktests-subsystem-399
+subnqn:  blktests-subsystem-398
 =====Discovery Log Entry 400======
 trtype:  loop
-subnqn:  blktests-subsystem-400
+subnqn:  blktests-subsystem-399
 =====Discovery Log Entry 401======
 trtype:  loop
-subnqn:  blktests-subsystem-401
+subnqn:  blktests-subsystem-400
 =====Discovery Log Entry 402======
 trtype:  loop
-subnqn:  blktests-subsystem-402
+subnqn:  blktests-subsystem-401
 =====Discovery Log Entry 403======
 trtype:  loop
-subnqn:  blktests-subsystem-403
+subnqn:  blktests-subsystem-402
 =====Discovery Log Entry 404======
 trtype:  loop
-subnqn:  blktests-subsystem-404
+subnqn:  blktests-subsystem-403
 =====Discovery Log Entry 405======
 trtype:  loop
-subnqn:  blktests-subsystem-405
+subnqn:  blktests-subsystem-404
 =====Discovery Log Entry 406======
 trtype:  loop
-subnqn:  blktests-subsystem-406
+subnqn:  blktests-subsystem-405
 =====Discovery Log Entry 407======
 trtype:  loop
-subnqn:  blktests-subsystem-407
+subnqn:  blktests-subsystem-406
 =====Discovery Log Entry 408======
 trtype:  loop
-subnqn:  blktests-subsystem-408
+subnqn:  blktests-subsystem-407
 =====Discovery Log Entry 409======
 trtype:  loop
-subnqn:  blktests-subsystem-409
+subnqn:  blktests-subsystem-408
 =====Discovery Log Entry 410======
 trtype:  loop
-subnqn:  blktests-subsystem-410
+subnqn:  blktests-subsystem-409
 =====Discovery Log Entry 411======
 trtype:  loop
-subnqn:  blktests-subsystem-411
+subnqn:  blktests-subsystem-410
 =====Discovery Log Entry 412======
 trtype:  loop
-subnqn:  blktests-subsystem-412
+subnqn:  blktests-subsystem-411
 =====Discovery Log Entry 413======
 trtype:  loop
-subnqn:  blktests-subsystem-413
+subnqn:  blktests-subsystem-412
 =====Discovery Log Entry 414======
 trtype:  loop
-subnqn:  blktests-subsystem-414
+subnqn:  blktests-subsystem-413
 =====Discovery Log Entry 415======
 trtype:  loop
-subnqn:  blktests-subsystem-415
+subnqn:  blktests-subsystem-414
 =====Discovery Log Entry 416======
 trtype:  loop
-subnqn:  blktests-subsystem-416
+subnqn:  blktests-subsystem-415
 =====Discovery Log Entry 417======
 trtype:  loop
-subnqn:  blktests-subsystem-417
+subnqn:  blktests-subsystem-416
 =====Discovery Log Entry 418======
 trtype:  loop
-subnqn:  blktests-subsystem-418
+subnqn:  blktests-subsystem-417
 =====Discovery Log Entry 419======
 trtype:  loop
-subnqn:  blktests-subsystem-419
+subnqn:  blktests-subsystem-418
 =====Discovery Log Entry 420======
 trtype:  loop
-subnqn:  blktests-subsystem-420
+subnqn:  blktests-subsystem-419
 =====Discovery Log Entry 421======
 trtype:  loop
-subnqn:  blktests-subsystem-421
+subnqn:  blktests-subsystem-420
 =====Discovery Log Entry 422======
 trtype:  loop
-subnqn:  blktests-subsystem-422
+subnqn:  blktests-subsystem-421
 =====Discovery Log Entry 423======
 trtype:  loop
-subnqn:  blktests-subsystem-423
+subnqn:  blktests-subsystem-422
 =====Discovery Log Entry 424======
 trtype:  loop
-subnqn:  blktests-subsystem-424
+subnqn:  blktests-subsystem-423
 =====Discovery Log Entry 425======
 trtype:  loop
-subnqn:  blktests-subsystem-425
+subnqn:  blktests-subsystem-424
 =====Discovery Log Entry 426======
 trtype:  loop
-subnqn:  blktests-subsystem-426
+subnqn:  blktests-subsystem-425
 =====Discovery Log Entry 427======
 trtype:  loop
-subnqn:  blktests-subsystem-427
+subnqn:  blktests-subsystem-426
 =====Discovery Log Entry 428======
 trtype:  loop
-subnqn:  blktests-subsystem-428
+subnqn:  blktests-subsystem-427
 =====Discovery Log Entry 429======
 trtype:  loop
-subnqn:  blktests-subsystem-429
+subnqn:  blktests-subsystem-428
 =====Discovery Log Entry 430======
 trtype:  loop
-subnqn:  blktests-subsystem-430
+subnqn:  blktests-subsystem-429
 =====Discovery Log Entry 431======
 trtype:  loop
-subnqn:  blktests-subsystem-431
+subnqn:  blktests-subsystem-430
 =====Discovery Log Entry 432======
 trtype:  loop
-subnqn:  blktests-subsystem-432
+subnqn:  blktests-subsystem-431
 =====Discovery Log Entry 433======
 trtype:  loop
-subnqn:  blktests-subsystem-433
+subnqn:  blktests-subsystem-432
 =====Discovery Log Entry 434======
 trtype:  loop
-subnqn:  blktests-subsystem-434
+subnqn:  blktests-subsystem-433
 =====Discovery Log Entry 435======
 trtype:  loop
-subnqn:  blktests-subsystem-435
+subnqn:  blktests-subsystem-434
 =====Discovery Log Entry 436======
 trtype:  loop
-subnqn:  blktests-subsystem-436
+subnqn:  blktests-subsystem-435
 =====Discovery Log Entry 437======
 trtype:  loop
-subnqn:  blktests-subsystem-437
+subnqn:  blktests-subsystem-436
 =====Discovery Log Entry 438======
 trtype:  loop
-subnqn:  blktests-subsystem-438
+subnqn:  blktests-subsystem-437
 =====Discovery Log Entry 439======
 trtype:  loop
-subnqn:  blktests-subsystem-439
+subnqn:  blktests-subsystem-438
 =====Discovery Log Entry 440======
 trtype:  loop
-subnqn:  blktests-subsystem-440
+subnqn:  blktests-subsystem-439
 =====Discovery Log Entry 441======
 trtype:  loop
-subnqn:  blktests-subsystem-441
+subnqn:  blktests-subsystem-440
 =====Discovery Log Entry 442======
 trtype:  loop
-subnqn:  blktests-subsystem-442
+subnqn:  blktests-subsystem-441
 =====Discovery Log Entry 443======
 trtype:  loop
-subnqn:  blktests-subsystem-443
+subnqn:  blktests-subsystem-442
 =====Discovery Log Entry 444======
 trtype:  loop
-subnqn:  blktests-subsystem-444
+subnqn:  blktests-subsystem-443
 =====Discovery Log Entry 445======
 trtype:  loop
-subnqn:  blktests-subsystem-445
+subnqn:  blktests-subsystem-444
 =====Discovery Log Entry 446======
 trtype:  loop
-subnqn:  blktests-subsystem-446
+subnqn:  blktests-subsystem-445
 =====Discovery Log Entry 447======
 trtype:  loop
-subnqn:  blktests-subsystem-447
+subnqn:  blktests-subsystem-446
 =====Discovery Log Entry 448======
 trtype:  loop
-subnqn:  blktests-subsystem-448
+subnqn:  blktests-subsystem-447
 =====Discovery Log Entry 449======
 trtype:  loop
-subnqn:  blktests-subsystem-449
+subnqn:  blktests-subsystem-448
 =====Discovery Log Entry 450======
 trtype:  loop
-subnqn:  blktests-subsystem-450
+subnqn:  blktests-subsystem-449
 =====Discovery Log Entry 451======
 trtype:  loop
-subnqn:  blktests-subsystem-451
+subnqn:  blktests-subsystem-450
 =====Discovery Log Entry 452======
 trtype:  loop
-subnqn:  blktests-subsystem-452
+subnqn:  blktests-subsystem-451
 =====Discovery Log Entry 453======
 trtype:  loop
-subnqn:  blktests-subsystem-453
+subnqn:  blktests-subsystem-452
 =====Discovery Log Entry 454======
 trtype:  loop
-subnqn:  blktests-subsystem-454
+subnqn:  blktests-subsystem-453
 =====Discovery Log Entry 455======
 trtype:  loop
-subnqn:  blktests-subsystem-455
+subnqn:  blktests-subsystem-454
 =====Discovery Log Entry 456======
 trtype:  loop
-subnqn:  blktests-subsystem-456
+subnqn:  blktests-subsystem-455
 =====Discovery Log Entry 457======
 trtype:  loop
-subnqn:  blktests-subsystem-457
+subnqn:  blktests-subsystem-456
 =====Discovery Log Entry 458======
 trtype:  loop
-subnqn:  blktests-subsystem-458
+subnqn:  blktests-subsystem-457
 =====Discovery Log Entry 459======
 trtype:  loop
-subnqn:  blktests-subsystem-459
+subnqn:  blktests-subsystem-458
 =====Discovery Log Entry 460======
 trtype:  loop
-subnqn:  blktests-subsystem-460
+subnqn:  blktests-subsystem-459
 =====Discovery Log Entry 461======
 trtype:  loop
-subnqn:  blktests-subsystem-461
+subnqn:  blktests-subsystem-460
 =====Discovery Log Entry 462======
 trtype:  loop
-subnqn:  blktests-subsystem-462
+subnqn:  blktests-subsystem-461
 =====Discovery Log Entry 463======
 trtype:  loop
-subnqn:  blktests-subsystem-463
+subnqn:  blktests-subsystem-462
 =====Discovery Log Entry 464======
 trtype:  loop
-subnqn:  blktests-subsystem-464
+subnqn:  blktests-subsystem-463
 =====Discovery Log Entry 465======
 trtype:  loop
-subnqn:  blktests-subsystem-465
+subnqn:  blktests-subsystem-464
 =====Discovery Log Entry 466======
 trtype:  loop
-subnqn:  blktests-subsystem-466
+subnqn:  blktests-subsystem-465
 =====Discovery Log Entry 467======
 trtype:  loop
-subnqn:  blktests-subsystem-467
+subnqn:  blktests-subsystem-466
 =====Discovery Log Entry 468======
 trtype:  loop
-subnqn:  blktests-subsystem-468
+subnqn:  blktests-subsystem-467
 =====Discovery Log Entry 469======
 trtype:  loop
-subnqn:  blktests-subsystem-469
+subnqn:  blktests-subsystem-468
 =====Discovery Log Entry 470======
 trtype:  loop
-subnqn:  blktests-subsystem-470
+subnqn:  blktests-subsystem-469
 =====Discovery Log Entry 471======
 trtype:  loop
-subnqn:  blktests-subsystem-471
+subnqn:  blktests-subsystem-470
 =====Discovery Log Entry 472======
 trtype:  loop
-subnqn:  blktests-subsystem-472
+subnqn:  blktests-subsystem-471
 =====Discovery Log Entry 473======
 trtype:  loop
-subnqn:  blktests-subsystem-473
+subnqn:  blktests-subsystem-472
 =====Discovery Log Entry 474======
 trtype:  loop
-subnqn:  blktests-subsystem-474
+subnqn:  blktests-subsystem-473
 =====Discovery Log Entry 475======
 trtype:  loop
-subnqn:  blktests-subsystem-475
+subnqn:  blktests-subsystem-474
 =====Discovery Log Entry 476======
 trtype:  loop
-subnqn:  blktests-subsystem-476
+subnqn:  blktests-subsystem-475
 =====Discovery Log Entry 477======
 trtype:  loop
-subnqn:  blktests-subsystem-477
+subnqn:  blktests-subsystem-476
 =====Discovery Log Entry 478======
 trtype:  loop
-subnqn:  blktests-subsystem-478
+subnqn:  blktests-subsystem-477
 =====Discovery Log Entry 479======
 trtype:  loop
-subnqn:  blktests-subsystem-479
+subnqn:  blktests-subsystem-478
 =====Discovery Log Entry 480======
 trtype:  loop
-subnqn:  blktests-subsystem-480
+subnqn:  blktests-subsystem-479
 =====Discovery Log Entry 481======
 trtype:  loop
-subnqn:  blktests-subsystem-481
+subnqn:  blktests-subsystem-480
 =====Discovery Log Entry 482======
 trtype:  loop
-subnqn:  blktests-subsystem-482
+subnqn:  blktests-subsystem-481
 =====Discovery Log Entry 483======
 trtype:  loop
-subnqn:  blktests-subsystem-483
+subnqn:  blktests-subsystem-482
 =====Discovery Log Entry 484======
 trtype:  loop
-subnqn:  blktests-subsystem-484
+subnqn:  blktests-subsystem-483
 =====Discovery Log Entry 485======
 trtype:  loop
-subnqn:  blktests-subsystem-485
+subnqn:  blktests-subsystem-484
 =====Discovery Log Entry 486======
 trtype:  loop
-subnqn:  blktests-subsystem-486
+subnqn:  blktests-subsystem-485
 =====Discovery Log Entry 487======
 trtype:  loop
-subnqn:  blktests-subsystem-487
+subnqn:  blktests-subsystem-486
 =====Discovery Log Entry 488======
 trtype:  loop
-subnqn:  blktests-subsystem-488
+subnqn:  blktests-subsystem-487
 =====Discovery Log Entry 489======
 trtype:  loop
-subnqn:  blktests-subsystem-489
+subnqn:  blktests-subsystem-488
 =====Discovery Log Entry 490======
 trtype:  loop
-subnqn:  blktests-subsystem-490
+subnqn:  blktests-subsystem-489
 =====Discovery Log Entry 491======
 trtype:  loop
-subnqn:  blktests-subsystem-491
+subnqn:  blktests-subsystem-490
 =====Discovery Log Entry 492======
 trtype:  loop
-subnqn:  blktests-subsystem-492
+subnqn:  blktests-subsystem-491
 =====Discovery Log Entry 493======
 trtype:  loop
-subnqn:  blktests-subsystem-493
+subnqn:  blktests-subsystem-492
 =====Discovery Log Entry 494======
 trtype:  loop
-subnqn:  blktests-subsystem-494
+subnqn:  blktests-subsystem-493
 =====Discovery Log Entry 495======
 trtype:  loop
-subnqn:  blktests-subsystem-495
+subnqn:  blktests-subsystem-494
 =====Discovery Log Entry 496======
 trtype:  loop
-subnqn:  blktests-subsystem-496
+subnqn:  blktests-subsystem-495
 =====Discovery Log Entry 497======
 trtype:  loop
-subnqn:  blktests-subsystem-497
+subnqn:  blktests-subsystem-496
 =====Discovery Log Entry 498======
 trtype:  loop
-subnqn:  blktests-subsystem-498
+subnqn:  blktests-subsystem-497
 =====Discovery Log Entry 499======
 trtype:  loop
-subnqn:  blktests-subsystem-499
+subnqn:  blktests-subsystem-498
 =====Discovery Log Entry 500======
 trtype:  loop
-subnqn:  blktests-subsystem-500
+subnqn:  blktests-subsystem-499
 =====Discovery Log Entry 501======
 trtype:  loop
-subnqn:  blktests-subsystem-501
+subnqn:  blktests-subsystem-500
 =====Discovery Log Entry 502======
 trtype:  loop
-subnqn:  blktests-subsystem-502
+subnqn:  blktests-subsystem-501
 =====Discovery Log Entry 503======
 trtype:  loop
-subnqn:  blktests-subsystem-503
+subnqn:  blktests-subsystem-502
 =====Discovery Log Entry 504======
 trtype:  loop
-subnqn:  blktests-subsystem-504
+subnqn:  blktests-subsystem-503
 =====Discovery Log Entry 505======
 trtype:  loop
-subnqn:  blktests-subsystem-505
+subnqn:  blktests-subsystem-504
 =====Discovery Log Entry 506======
 trtype:  loop
-subnqn:  blktests-subsystem-506
+subnqn:  blktests-subsystem-505
 =====Discovery Log Entry 507======
 trtype:  loop
-subnqn:  blktests-subsystem-507
+subnqn:  blktests-subsystem-506
 =====Discovery Log Entry 508======
 trtype:  loop
-subnqn:  blktests-subsystem-508
+subnqn:  blktests-subsystem-507
 =====Discovery Log Entry 509======
 trtype:  loop
-subnqn:  blktests-subsystem-509
+subnqn:  blktests-subsystem-508
 =====Discovery Log Entry 510======
 trtype:  loop
-subnqn:  blktests-subsystem-510
+subnqn:  blktests-subsystem-509
 =====Discovery Log Entry 511======
 trtype:  loop
-subnqn:  blktests-subsystem-511
+subnqn:  blktests-subsystem-510
 =====Discovery Log Entry 512======
 trtype:  loop
-subnqn:  blktests-subsystem-512
+subnqn:  blktests-subsystem-511
 =====Discovery Log Entry 513======
 trtype:  loop
-subnqn:  blktests-subsystem-513
+subnqn:  blktests-subsystem-512
 =====Discovery Log Entry 514======
 trtype:  loop
-subnqn:  blktests-subsystem-514
+subnqn:  blktests-subsystem-513
 =====Discovery Log Entry 515======
 trtype:  loop
-subnqn:  blktests-subsystem-515
+subnqn:  blktests-subsystem-514
 =====Discovery Log Entry 516======
 trtype:  loop
-subnqn:  blktests-subsystem-516
+subnqn:  blktests-subsystem-515
 =====Discovery Log Entry 517======
 trtype:  loop
-subnqn:  blktests-subsystem-517
+subnqn:  blktests-subsystem-516
 =====Discovery Log Entry 518======
 trtype:  loop
-subnqn:  blktests-subsystem-518
+subnqn:  blktests-subsystem-517
 =====Discovery Log Entry 519======
 trtype:  loop
-subnqn:  blktests-subsystem-519
+subnqn:  blktests-subsystem-518
 =====Discovery Log Entry 520======
 trtype:  loop
-subnqn:  blktests-subsystem-520
+subnqn:  blktests-subsystem-519
 =====Discovery Log Entry 521======
 trtype:  loop
-subnqn:  blktests-subsystem-521
+subnqn:  blktests-subsystem-520
 =====Discovery Log Entry 522======
 trtype:  loop
-subnqn:  blktests-subsystem-522
+subnqn:  blktests-subsystem-521
 =====Discovery Log Entry 523======
 trtype:  loop
-subnqn:  blktests-subsystem-523
+subnqn:  blktests-subsystem-522
 =====Discovery Log Entry 524======
 trtype:  loop
-subnqn:  blktests-subsystem-524
+subnqn:  blktests-subsystem-523
 =====Discovery Log Entry 525======
 trtype:  loop
-subnqn:  blktests-subsystem-525
+subnqn:  blktests-subsystem-524
 =====Discovery Log Entry 526======
 trtype:  loop
-subnqn:  blktests-subsystem-526
+subnqn:  blktests-subsystem-525
 =====Discovery Log Entry 527======
 trtype:  loop
-subnqn:  blktests-subsystem-527
+subnqn:  blktests-subsystem-526
 =====Discovery Log Entry 528======
 trtype:  loop
-subnqn:  blktests-subsystem-528
+subnqn:  blktests-subsystem-527
 =====Discovery Log Entry 529======
 trtype:  loop
-subnqn:  blktests-subsystem-529
+subnqn:  blktests-subsystem-528
 =====Discovery Log Entry 530======
 trtype:  loop
-subnqn:  blktests-subsystem-530
+subnqn:  blktests-subsystem-529
 =====Discovery Log Entry 531======
 trtype:  loop
-subnqn:  blktests-subsystem-531
+subnqn:  blktests-subsystem-530
 =====Discovery Log Entry 532======
 trtype:  loop
-subnqn:  blktests-subsystem-532
+subnqn:  blktests-subsystem-531
 =====Discovery Log Entry 533======
 trtype:  loop
-subnqn:  blktests-subsystem-533
+subnqn:  blktests-subsystem-532
 =====Discovery Log Entry 534======
 trtype:  loop
-subnqn:  blktests-subsystem-534
+subnqn:  blktests-subsystem-533
 =====Discovery Log Entry 535======
 trtype:  loop
-subnqn:  blktests-subsystem-535
+subnqn:  blktests-subsystem-534
 =====Discovery Log Entry 536======
 trtype:  loop
-subnqn:  blktests-subsystem-536
+subnqn:  blktests-subsystem-535
 =====Discovery Log Entry 537======
 trtype:  loop
-subnqn:  blktests-subsystem-537
+subnqn:  blktests-subsystem-536
 =====Discovery Log Entry 538======
 trtype:  loop
-subnqn:  blktests-subsystem-538
+subnqn:  blktests-subsystem-537
 =====Discovery Log Entry 539======
 trtype:  loop
-subnqn:  blktests-subsystem-539
+subnqn:  blktests-subsystem-538
 =====Discovery Log Entry 540======
 trtype:  loop
-subnqn:  blktests-subsystem-540
+subnqn:  blktests-subsystem-539
 =====Discovery Log Entry 541======
 trtype:  loop
-subnqn:  blktests-subsystem-541
+subnqn:  blktests-subsystem-540
 =====Discovery Log Entry 542======
 trtype:  loop
-subnqn:  blktests-subsystem-542
+subnqn:  blktests-subsystem-541
 =====Discovery Log Entry 543======
 trtype:  loop
-subnqn:  blktests-subsystem-543
+subnqn:  blktests-subsystem-542
 =====Discovery Log Entry 544======
 trtype:  loop
-subnqn:  blktests-subsystem-544
+subnqn:  blktests-subsystem-543
 =====Discovery Log Entry 545======
 trtype:  loop
-subnqn:  blktests-subsystem-545
+subnqn:  blktests-subsystem-544
 =====Discovery Log Entry 546======
 trtype:  loop
-subnqn:  blktests-subsystem-546
+subnqn:  blktests-subsystem-545
 =====Discovery Log Entry 547======
 trtype:  loop
-subnqn:  blktests-subsystem-547
+subnqn:  blktests-subsystem-546
 =====Discovery Log Entry 548======
 trtype:  loop
-subnqn:  blktests-subsystem-548
+subnqn:  blktests-subsystem-547
 =====Discovery Log Entry 549======
 trtype:  loop
-subnqn:  blktests-subsystem-549
+subnqn:  blktests-subsystem-548
 =====Discovery Log Entry 550======
 trtype:  loop
-subnqn:  blktests-subsystem-550
+subnqn:  blktests-subsystem-549
 =====Discovery Log Entry 551======
 trtype:  loop
-subnqn:  blktests-subsystem-551
+subnqn:  blktests-subsystem-550
 =====Discovery Log Entry 552======
 trtype:  loop
-subnqn:  blktests-subsystem-552
+subnqn:  blktests-subsystem-551
 =====Discovery Log Entry 553======
 trtype:  loop
-subnqn:  blktests-subsystem-553
+subnqn:  blktests-subsystem-552
 =====Discovery Log Entry 554======
 trtype:  loop
-subnqn:  blktests-subsystem-554
+subnqn:  blktests-subsystem-553
 =====Discovery Log Entry 555======
 trtype:  loop
-subnqn:  blktests-subsystem-555
+subnqn:  blktests-subsystem-554
 =====Discovery Log Entry 556======
 trtype:  loop
-subnqn:  blktests-subsystem-556
+subnqn:  blktests-subsystem-555
 =====Discovery Log Entry 557======
 trtype:  loop
-subnqn:  blktests-subsystem-557
+subnqn:  blktests-subsystem-556
 =====Discovery Log Entry 558======
 trtype:  loop
-subnqn:  blktests-subsystem-558
+subnqn:  blktests-subsystem-557
 =====Discovery Log Entry 559======
 trtype:  loop
-subnqn:  blktests-subsystem-559
+subnqn:  blktests-subsystem-558
 =====Discovery Log Entry 560======
 trtype:  loop
-subnqn:  blktests-subsystem-560
+subnqn:  blktests-subsystem-559
 =====Discovery Log Entry 561======
 trtype:  loop
-subnqn:  blktests-subsystem-561
+subnqn:  blktests-subsystem-560
 =====Discovery Log Entry 562======
 trtype:  loop
-subnqn:  blktests-subsystem-562
+subnqn:  blktests-subsystem-561
 =====Discovery Log Entry 563======
 trtype:  loop
-subnqn:  blktests-subsystem-563
+subnqn:  blktests-subsystem-562
 =====Discovery Log Entry 564======
 trtype:  loop
-subnqn:  blktests-subsystem-564
+subnqn:  blktests-subsystem-563
 =====Discovery Log Entry 565======
 trtype:  loop
-subnqn:  blktests-subsystem-565
+subnqn:  blktests-subsystem-564
 =====Discovery Log Entry 566======
 trtype:  loop
-subnqn:  blktests-subsystem-566
+subnqn:  blktests-subsystem-565
 =====Discovery Log Entry 567======
 trtype:  loop
-subnqn:  blktests-subsystem-567
+subnqn:  blktests-subsystem-566
 =====Discovery Log Entry 568======
 trtype:  loop
-subnqn:  blktests-subsystem-568
+subnqn:  blktests-subsystem-567
 =====Discovery Log Entry 569======
 trtype:  loop
-subnqn:  blktests-subsystem-569
+subnqn:  blktests-subsystem-568
 =====Discovery Log Entry 570======
 trtype:  loop
-subnqn:  blktests-subsystem-570
+subnqn:  blktests-subsystem-569
 =====Discovery Log Entry 571======
 trtype:  loop
-subnqn:  blktests-subsystem-571
+subnqn:  blktests-subsystem-570
 =====Discovery Log Entry 572======
 trtype:  loop
-subnqn:  blktests-subsystem-572
+subnqn:  blktests-subsystem-571
 =====Discovery Log Entry 573======
 trtype:  loop
-subnqn:  blktests-subsystem-573
+subnqn:  blktests-subsystem-572
 =====Discovery Log Entry 574======
 trtype:  loop
-subnqn:  blktests-subsystem-574
+subnqn:  blktests-subsystem-573
 =====Discovery Log Entry 575======
 trtype:  loop
-subnqn:  blktests-subsystem-575
+subnqn:  blktests-subsystem-574
 =====Discovery Log Entry 576======
 trtype:  loop
-subnqn:  blktests-subsystem-576
+subnqn:  blktests-subsystem-575
 =====Discovery Log Entry 577======
 trtype:  loop
-subnqn:  blktests-subsystem-577
+subnqn:  blktests-subsystem-576
 =====Discovery Log Entry 578======
 trtype:  loop
-subnqn:  blktests-subsystem-578
+subnqn:  blktests-subsystem-577
 =====Discovery Log Entry 579======
 trtype:  loop
-subnqn:  blktests-subsystem-579
+subnqn:  blktests-subsystem-578
 =====Discovery Log Entry 580======
 trtype:  loop
-subnqn:  blktests-subsystem-580
+subnqn:  blktests-subsystem-579
 =====Discovery Log Entry 581======
 trtype:  loop
-subnqn:  blktests-subsystem-581
+subnqn:  blktests-subsystem-580
 =====Discovery Log Entry 582======
 trtype:  loop
-subnqn:  blktests-subsystem-582
+subnqn:  blktests-subsystem-581
 =====Discovery Log Entry 583======
 trtype:  loop
-subnqn:  blktests-subsystem-583
+subnqn:  blktests-subsystem-582
 =====Discovery Log Entry 584======
 trtype:  loop
-subnqn:  blktests-subsystem-584
+subnqn:  blktests-subsystem-583
 =====Discovery Log Entry 585======
 trtype:  loop
-subnqn:  blktests-subsystem-585
+subnqn:  blktests-subsystem-584
 =====Discovery Log Entry 586======
 trtype:  loop
-subnqn:  blktests-subsystem-586
+subnqn:  blktests-subsystem-585
 =====Discovery Log Entry 587======
 trtype:  loop
-subnqn:  blktests-subsystem-587
+subnqn:  blktests-subsystem-586
 =====Discovery Log Entry 588======
 trtype:  loop
-subnqn:  blktests-subsystem-588
+subnqn:  blktests-subsystem-587
 =====Discovery Log Entry 589======
 trtype:  loop
-subnqn:  blktests-subsystem-589
+subnqn:  blktests-subsystem-588
 =====Discovery Log Entry 590======
 trtype:  loop
-subnqn:  blktests-subsystem-590
+subnqn:  blktests-subsystem-589
 =====Discovery Log Entry 591======
 trtype:  loop
-subnqn:  blktests-subsystem-591
+subnqn:  blktests-subsystem-590
 =====Discovery Log Entry 592======
 trtype:  loop
-subnqn:  blktests-subsystem-592
+subnqn:  blktests-subsystem-591
 =====Discovery Log Entry 593======
 trtype:  loop
-subnqn:  blktests-subsystem-593
+subnqn:  blktests-subsystem-592
 =====Discovery Log Entry 594======
 trtype:  loop
-subnqn:  blktests-subsystem-594
+subnqn:  blktests-subsystem-593
 =====Discovery Log Entry 595======
 trtype:  loop
-subnqn:  blktests-subsystem-595
+subnqn:  blktests-subsystem-594
 =====Discovery Log Entry 596======
 trtype:  loop
-subnqn:  blktests-subsystem-596
+subnqn:  blktests-subsystem-595
 =====Discovery Log Entry 597======
 trtype:  loop
-subnqn:  blktests-subsystem-597
+subnqn:  blktests-subsystem-596
 =====Discovery Log Entry 598======
 trtype:  loop
-subnqn:  blktests-subsystem-598
+subnqn:  blktests-subsystem-597
 =====Discovery Log Entry 599======
 trtype:  loop
-subnqn:  blktests-subsystem-599
+subnqn:  blktests-subsystem-598
 =====Discovery Log Entry 600======
 trtype:  loop
-subnqn:  blktests-subsystem-600
+subnqn:  blktests-subsystem-599
 =====Discovery Log Entry 601======
 trtype:  loop
-subnqn:  blktests-subsystem-601
+subnqn:  blktests-subsystem-600
 =====Discovery Log Entry 602======
 trtype:  loop
-subnqn:  blktests-subsystem-602
+subnqn:  blktests-subsystem-601
 =====Discovery Log Entry 603======
 trtype:  loop
-subnqn:  blktests-subsystem-603
+subnqn:  blktests-subsystem-602
 =====Discovery Log Entry 604======
 trtype:  loop
-subnqn:  blktests-subsystem-604
+subnqn:  blktests-subsystem-603
 =====Discovery Log Entry 605======
 trtype:  loop
-subnqn:  blktests-subsystem-605
+subnqn:  blktests-subsystem-604
 =====Discovery Log Entry 606======
 trtype:  loop
-subnqn:  blktests-subsystem-606
+subnqn:  blktests-subsystem-605
 =====Discovery Log Entry 607======
 trtype:  loop
-subnqn:  blktests-subsystem-607
+subnqn:  blktests-subsystem-606
 =====Discovery Log Entry 608======
 trtype:  loop
-subnqn:  blktests-subsystem-608
+subnqn:  blktests-subsystem-607
 =====Discovery Log Entry 609======
 trtype:  loop
-subnqn:  blktests-subsystem-609
+subnqn:  blktests-subsystem-608
 =====Discovery Log Entry 610======
 trtype:  loop
-subnqn:  blktests-subsystem-610
+subnqn:  blktests-subsystem-609
 =====Discovery Log Entry 611======
 trtype:  loop
-subnqn:  blktests-subsystem-611
+subnqn:  blktests-subsystem-610
 =====Discovery Log Entry 612======
 trtype:  loop
-subnqn:  blktests-subsystem-612
+subnqn:  blktests-subsystem-611
 =====Discovery Log Entry 613======
 trtype:  loop
-subnqn:  blktests-subsystem-613
+subnqn:  blktests-subsystem-612
 =====Discovery Log Entry 614======
 trtype:  loop
-subnqn:  blktests-subsystem-614
+subnqn:  blktests-subsystem-613
 =====Discovery Log Entry 615======
 trtype:  loop
-subnqn:  blktests-subsystem-615
+subnqn:  blktests-subsystem-614
 =====Discovery Log Entry 616======
 trtype:  loop
-subnqn:  blktests-subsystem-616
+subnqn:  blktests-subsystem-615
 =====Discovery Log Entry 617======
 trtype:  loop
-subnqn:  blktests-subsystem-617
+subnqn:  blktests-subsystem-616
 =====Discovery Log Entry 618======
 trtype:  loop
-subnqn:  blktests-subsystem-618
+subnqn:  blktests-subsystem-617
 =====Discovery Log Entry 619======
 trtype:  loop
-subnqn:  blktests-subsystem-619
+subnqn:  blktests-subsystem-618
 =====Discovery Log Entry 620======
 trtype:  loop
-subnqn:  blktests-subsystem-620
+subnqn:  blktests-subsystem-619
 =====Discovery Log Entry 621======
 trtype:  loop
-subnqn:  blktests-subsystem-621
+subnqn:  blktests-subsystem-620
 =====Discovery Log Entry 622======
 trtype:  loop
-subnqn:  blktests-subsystem-622
+subnqn:  blktests-subsystem-621
 =====Discovery Log Entry 623======
 trtype:  loop
-subnqn:  blktests-subsystem-623
+subnqn:  blktests-subsystem-622
 =====Discovery Log Entry 624======
 trtype:  loop
-subnqn:  blktests-subsystem-624
+subnqn:  blktests-subsystem-623
 =====Discovery Log Entry 625======
 trtype:  loop
-subnqn:  blktests-subsystem-625
+subnqn:  blktests-subsystem-624
 =====Discovery Log Entry 626======
 trtype:  loop
-subnqn:  blktests-subsystem-626
+subnqn:  blktests-subsystem-625
 =====Discovery Log Entry 627======
 trtype:  loop
-subnqn:  blktests-subsystem-627
+subnqn:  blktests-subsystem-626
 =====Discovery Log Entry 628======
 trtype:  loop
-subnqn:  blktests-subsystem-628
+subnqn:  blktests-subsystem-627
 =====Discovery Log Entry 629======
 trtype:  loop
-subnqn:  blktests-subsystem-629
+subnqn:  blktests-subsystem-628
 =====Discovery Log Entry 630======
 trtype:  loop
-subnqn:  blktests-subsystem-630
+subnqn:  blktests-subsystem-629
 =====Discovery Log Entry 631======
 trtype:  loop
-subnqn:  blktests-subsystem-631
+subnqn:  blktests-subsystem-630
 =====Discovery Log Entry 632======
 trtype:  loop
-subnqn:  blktests-subsystem-632
+subnqn:  blktests-subsystem-631
 =====Discovery Log Entry 633======
 trtype:  loop
-subnqn:  blktests-subsystem-633
+subnqn:  blktests-subsystem-632
 =====Discovery Log Entry 634======
 trtype:  loop
-subnqn:  blktests-subsystem-634
+subnqn:  blktests-subsystem-633
 =====Discovery Log Entry 635======
 trtype:  loop
-subnqn:  blktests-subsystem-635
+subnqn:  blktests-subsystem-634
 =====Discovery Log Entry 636======
 trtype:  loop
-subnqn:  blktests-subsystem-636
+subnqn:  blktests-subsystem-635
 =====Discovery Log Entry 637======
 trtype:  loop
-subnqn:  blktests-subsystem-637
+subnqn:  blktests-subsystem-636
 =====Discovery Log Entry 638======
 trtype:  loop
-subnqn:  blktests-subsystem-638
+subnqn:  blktests-subsystem-637
 =====Discovery Log Entry 639======
 trtype:  loop
-subnqn:  blktests-subsystem-639
+subnqn:  blktests-subsystem-638
 =====Discovery Log Entry 640======
 trtype:  loop
-subnqn:  blktests-subsystem-640
+subnqn:  blktests-subsystem-639
 =====Discovery Log Entry 641======
 trtype:  loop
-subnqn:  blktests-subsystem-641
+subnqn:  blktests-subsystem-640
 =====Discovery Log Entry 642======
 trtype:  loop
-subnqn:  blktests-subsystem-642
+subnqn:  blktests-subsystem-641
 =====Discovery Log Entry 643======
 trtype:  loop
-subnqn:  blktests-subsystem-643
+subnqn:  blktests-subsystem-642
 =====Discovery Log Entry 644======
 trtype:  loop
-subnqn:  blktests-subsystem-644
+subnqn:  blktests-subsystem-643
 =====Discovery Log Entry 645======
 trtype:  loop
-subnqn:  blktests-subsystem-645
+subnqn:  blktests-subsystem-644
 =====Discovery Log Entry 646======
 trtype:  loop
-subnqn:  blktests-subsystem-646
+subnqn:  blktests-subsystem-645
 =====Discovery Log Entry 647======
 trtype:  loop
-subnqn:  blktests-subsystem-647
+subnqn:  blktests-subsystem-646
 =====Discovery Log Entry 648======
 trtype:  loop
-subnqn:  blktests-subsystem-648
+subnqn:  blktests-subsystem-647
 =====Discovery Log Entry 649======
 trtype:  loop
-subnqn:  blktests-subsystem-649
+subnqn:  blktests-subsystem-648
 =====Discovery Log Entry 650======
 trtype:  loop
-subnqn:  blktests-subsystem-650
+subnqn:  blktests-subsystem-649
 =====Discovery Log Entry 651======
 trtype:  loop
-subnqn:  blktests-subsystem-651
+subnqn:  blktests-subsystem-650
 =====Discovery Log Entry 652======
 trtype:  loop
-subnqn:  blktests-subsystem-652
+subnqn:  blktests-subsystem-651
 =====Discovery Log Entry 653======
 trtype:  loop
-subnqn:  blktests-subsystem-653
+subnqn:  blktests-subsystem-652
 =====Discovery Log Entry 654======
 trtype:  loop
-subnqn:  blktests-subsystem-654
+subnqn:  blktests-subsystem-653
 =====Discovery Log Entry 655======
 trtype:  loop
-subnqn:  blktests-subsystem-655
+subnqn:  blktests-subsystem-654
 =====Discovery Log Entry 656======
 trtype:  loop
-subnqn:  blktests-subsystem-656
+subnqn:  blktests-subsystem-655
 =====Discovery Log Entry 657======
 trtype:  loop
-subnqn:  blktests-subsystem-657
+subnqn:  blktests-subsystem-656
 =====Discovery Log Entry 658======
 trtype:  loop
-subnqn:  blktests-subsystem-658
+subnqn:  blktests-subsystem-657
 =====Discovery Log Entry 659======
 trtype:  loop
-subnqn:  blktests-subsystem-659
+subnqn:  blktests-subsystem-658
 =====Discovery Log Entry 660======
 trtype:  loop
-subnqn:  blktests-subsystem-660
+subnqn:  blktests-subsystem-659
 =====Discovery Log Entry 661======
 trtype:  loop
-subnqn:  blktests-subsystem-661
+subnqn:  blktests-subsystem-660
 =====Discovery Log Entry 662======
 trtype:  loop
-subnqn:  blktests-subsystem-662
+subnqn:  blktests-subsystem-661
 =====Discovery Log Entry 663======
 trtype:  loop
-subnqn:  blktests-subsystem-663
+subnqn:  blktests-subsystem-662
 =====Discovery Log Entry 664======
 trtype:  loop
-subnqn:  blktests-subsystem-664
+subnqn:  blktests-subsystem-663
 =====Discovery Log Entry 665======
 trtype:  loop
-subnqn:  blktests-subsystem-665
+subnqn:  blktests-subsystem-664
 =====Discovery Log Entry 666======
 trtype:  loop
-subnqn:  blktests-subsystem-666
+subnqn:  blktests-subsystem-665
 =====Discovery Log Entry 667======
 trtype:  loop
-subnqn:  blktests-subsystem-667
+subnqn:  blktests-subsystem-666
 =====Discovery Log Entry 668======
 trtype:  loop
-subnqn:  blktests-subsystem-668
+subnqn:  blktests-subsystem-667
 =====Discovery Log Entry 669======
 trtype:  loop
-subnqn:  blktests-subsystem-669
+subnqn:  blktests-subsystem-668
 =====Discovery Log Entry 670======
 trtype:  loop
-subnqn:  blktests-subsystem-670
+subnqn:  blktests-subsystem-669
 =====Discovery Log Entry 671======
 trtype:  loop
-subnqn:  blktests-subsystem-671
+subnqn:  blktests-subsystem-670
 =====Discovery Log Entry 672======
 trtype:  loop
-subnqn:  blktests-subsystem-672
+subnqn:  blktests-subsystem-671
 =====Discovery Log Entry 673======
 trtype:  loop
-subnqn:  blktests-subsystem-673
+subnqn:  blktests-subsystem-672
 =====Discovery Log Entry 674======
 trtype:  loop
-subnqn:  blktests-subsystem-674
+subnqn:  blktests-subsystem-673
 =====Discovery Log Entry 675======
 trtype:  loop
-subnqn:  blktests-subsystem-675
+subnqn:  blktests-subsystem-674
 =====Discovery Log Entry 676======
 trtype:  loop
-subnqn:  blktests-subsystem-676
+subnqn:  blktests-subsystem-675
 =====Discovery Log Entry 677======
 trtype:  loop
-subnqn:  blktests-subsystem-677
+subnqn:  blktests-subsystem-676
 =====Discovery Log Entry 678======
 trtype:  loop
-subnqn:  blktests-subsystem-678
+subnqn:  blktests-subsystem-677
 =====Discovery Log Entry 679======
 trtype:  loop
-subnqn:  blktests-subsystem-679
+subnqn:  blktests-subsystem-678
 =====Discovery Log Entry 680======
 trtype:  loop
-subnqn:  blktests-subsystem-680
+subnqn:  blktests-subsystem-679
 =====Discovery Log Entry 681======
 trtype:  loop
-subnqn:  blktests-subsystem-681
+subnqn:  blktests-subsystem-680
 =====Discovery Log Entry 682======
 trtype:  loop
-subnqn:  blktests-subsystem-682
+subnqn:  blktests-subsystem-681
 =====Discovery Log Entry 683======
 trtype:  loop
-subnqn:  blktests-subsystem-683
+subnqn:  blktests-subsystem-682
 =====Discovery Log Entry 684======
 trtype:  loop
-subnqn:  blktests-subsystem-684
+subnqn:  blktests-subsystem-683
 =====Discovery Log Entry 685======
 trtype:  loop
-subnqn:  blktests-subsystem-685
+subnqn:  blktests-subsystem-684
 =====Discovery Log Entry 686======
 trtype:  loop
-subnqn:  blktests-subsystem-686
+subnqn:  blktests-subsystem-685
 =====Discovery Log Entry 687======
 trtype:  loop
-subnqn:  blktests-subsystem-687
+subnqn:  blktests-subsystem-686
 =====Discovery Log Entry 688======
 trtype:  loop
-subnqn:  blktests-subsystem-688
+subnqn:  blktests-subsystem-687
 =====Discovery Log Entry 689======
 trtype:  loop
-subnqn:  blktests-subsystem-689
+subnqn:  blktests-subsystem-688
 =====Discovery Log Entry 690======
 trtype:  loop
-subnqn:  blktests-subsystem-690
+subnqn:  blktests-subsystem-689
 =====Discovery Log Entry 691======
 trtype:  loop
-subnqn:  blktests-subsystem-691
+subnqn:  blktests-subsystem-690
 =====Discovery Log Entry 692======
 trtype:  loop
-subnqn:  blktests-subsystem-692
+subnqn:  blktests-subsystem-691
 =====Discovery Log Entry 693======
 trtype:  loop
-subnqn:  blktests-subsystem-693
+subnqn:  blktests-subsystem-692
 =====Discovery Log Entry 694======
 trtype:  loop
-subnqn:  blktests-subsystem-694
+subnqn:  blktests-subsystem-693
 =====Discovery Log Entry 695======
 trtype:  loop
-subnqn:  blktests-subsystem-695
+subnqn:  blktests-subsystem-694
 =====Discovery Log Entry 696======
 trtype:  loop
-subnqn:  blktests-subsystem-696
+subnqn:  blktests-subsystem-695
 =====Discovery Log Entry 697======
 trtype:  loop
-subnqn:  blktests-subsystem-697
+subnqn:  blktests-subsystem-696
 =====Discovery Log Entry 698======
 trtype:  loop
-subnqn:  blktests-subsystem-698
+subnqn:  blktests-subsystem-697
 =====Discovery Log Entry 699======
 trtype:  loop
-subnqn:  blktests-subsystem-699
+subnqn:  blktests-subsystem-698
 =====Discovery Log Entry 700======
 trtype:  loop
-subnqn:  blktests-subsystem-700
+subnqn:  blktests-subsystem-699
 =====Discovery Log Entry 701======
 trtype:  loop
-subnqn:  blktests-subsystem-701
+subnqn:  blktests-subsystem-700
 =====Discovery Log Entry 702======
 trtype:  loop
-subnqn:  blktests-subsystem-702
+subnqn:  blktests-subsystem-701
 =====Discovery Log Entry 703======
 trtype:  loop
-subnqn:  blktests-subsystem-703
+subnqn:  blktests-subsystem-702
 =====Discovery Log Entry 704======
 trtype:  loop
-subnqn:  blktests-subsystem-704
+subnqn:  blktests-subsystem-703
 =====Discovery Log Entry 705======
 trtype:  loop
-subnqn:  blktests-subsystem-705
+subnqn:  blktests-subsystem-704
 =====Discovery Log Entry 706======
 trtype:  loop
-subnqn:  blktests-subsystem-706
+subnqn:  blktests-subsystem-705
 =====Discovery Log Entry 707======
 trtype:  loop
-subnqn:  blktests-subsystem-707
+subnqn:  blktests-subsystem-706
 =====Discovery Log Entry 708======
 trtype:  loop
-subnqn:  blktests-subsystem-708
+subnqn:  blktests-subsystem-707
 =====Discovery Log Entry 709======
 trtype:  loop
-subnqn:  blktests-subsystem-709
+subnqn:  blktests-subsystem-708
 =====Discovery Log Entry 710======
 trtype:  loop
-subnqn:  blktests-subsystem-710
+subnqn:  blktests-subsystem-709
 =====Discovery Log Entry 711======
 trtype:  loop
-subnqn:  blktests-subsystem-711
+subnqn:  blktests-subsystem-710
 =====Discovery Log Entry 712======
 trtype:  loop
-subnqn:  blktests-subsystem-712
+subnqn:  blktests-subsystem-711
 =====Discovery Log Entry 713======
 trtype:  loop
-subnqn:  blktests-subsystem-713
+subnqn:  blktests-subsystem-712
 =====Discovery Log Entry 714======
 trtype:  loop
-subnqn:  blktests-subsystem-714
+subnqn:  blktests-subsystem-713
 =====Discovery Log Entry 715======
 trtype:  loop
-subnqn:  blktests-subsystem-715
+subnqn:  blktests-subsystem-714
 =====Discovery Log Entry 716======
 trtype:  loop
-subnqn:  blktests-subsystem-716
+subnqn:  blktests-subsystem-715
 =====Discovery Log Entry 717======
 trtype:  loop
-subnqn:  blktests-subsystem-717
+subnqn:  blktests-subsystem-716
 =====Discovery Log Entry 718======
 trtype:  loop
-subnqn:  blktests-subsystem-718
+subnqn:  blktests-subsystem-717
 =====Discovery Log Entry 719======
 trtype:  loop
-subnqn:  blktests-subsystem-719
+subnqn:  blktests-subsystem-718
 =====Discovery Log Entry 720======
 trtype:  loop
-subnqn:  blktests-subsystem-720
+subnqn:  blktests-subsystem-719
 =====Discovery Log Entry 721======
 trtype:  loop
-subnqn:  blktests-subsystem-721
+subnqn:  blktests-subsystem-720
 =====Discovery Log Entry 722======
 trtype:  loop
-subnqn:  blktests-subsystem-722
+subnqn:  blktests-subsystem-721
 =====Discovery Log Entry 723======
 trtype:  loop
-subnqn:  blktests-subsystem-723
+subnqn:  blktests-subsystem-722
 =====Discovery Log Entry 724======
 trtype:  loop
-subnqn:  blktests-subsystem-724
+subnqn:  blktests-subsystem-723
 =====Discovery Log Entry 725======
 trtype:  loop
-subnqn:  blktests-subsystem-725
+subnqn:  blktests-subsystem-724
 =====Discovery Log Entry 726======
 trtype:  loop
-subnqn:  blktests-subsystem-726
+subnqn:  blktests-subsystem-725
 =====Discovery Log Entry 727======
 trtype:  loop
-subnqn:  blktests-subsystem-727
+subnqn:  blktests-subsystem-726
 =====Discovery Log Entry 728======
 trtype:  loop
-subnqn:  blktests-subsystem-728
+subnqn:  blktests-subsystem-727
 =====Discovery Log Entry 729======
 trtype:  loop
-subnqn:  blktests-subsystem-729
+subnqn:  blktests-subsystem-728
 =====Discovery Log Entry 730======
 trtype:  loop
-subnqn:  blktests-subsystem-730
+subnqn:  blktests-subsystem-729
 =====Discovery Log Entry 731======
 trtype:  loop
-subnqn:  blktests-subsystem-731
+subnqn:  blktests-subsystem-730
 =====Discovery Log Entry 732======
 trtype:  loop
-subnqn:  blktests-subsystem-732
+subnqn:  blktests-subsystem-731
 =====Discovery Log Entry 733======
 trtype:  loop
-subnqn:  blktests-subsystem-733
+subnqn:  blktests-subsystem-732
 =====Discovery Log Entry 734======
 trtype:  loop
-subnqn:  blktests-subsystem-734
+subnqn:  blktests-subsystem-733
 =====Discovery Log Entry 735======
 trtype:  loop
-subnqn:  blktests-subsystem-735
+subnqn:  blktests-subsystem-734
 =====Discovery Log Entry 736======
 trtype:  loop
-subnqn:  blktests-subsystem-736
+subnqn:  blktests-subsystem-735
 =====Discovery Log Entry 737======
 trtype:  loop
-subnqn:  blktests-subsystem-737
+subnqn:  blktests-subsystem-736
 =====Discovery Log Entry 738======
 trtype:  loop
-subnqn:  blktests-subsystem-738
+subnqn:  blktests-subsystem-737
 =====Discovery Log Entry 739======
 trtype:  loop
-subnqn:  blktests-subsystem-739
+subnqn:  blktests-subsystem-738
 =====Discovery Log Entry 740======
 trtype:  loop
-subnqn:  blktests-subsystem-740
+subnqn:  blktests-subsystem-739
 =====Discovery Log Entry 741======
 trtype:  loop
-subnqn:  blktests-subsystem-741
+subnqn:  blktests-subsystem-740
 =====Discovery Log Entry 742======
 trtype:  loop
-subnqn:  blktests-subsystem-742
+subnqn:  blktests-subsystem-741
 =====Discovery Log Entry 743======
 trtype:  loop
-subnqn:  blktests-subsystem-743
+subnqn:  blktests-subsystem-742
 =====Discovery Log Entry 744======
 trtype:  loop
-subnqn:  blktests-subsystem-744
+subnqn:  blktests-subsystem-743
 =====Discovery Log Entry 745======
 trtype:  loop
-subnqn:  blktests-subsystem-745
+subnqn:  blktests-subsystem-744
 =====Discovery Log Entry 746======
 trtype:  loop
-subnqn:  blktests-subsystem-746
+subnqn:  blktests-subsystem-745
 =====Discovery Log Entry 747======
 trtype:  loop
-subnqn:  blktests-subsystem-747
+subnqn:  blktests-subsystem-746
 =====Discovery Log Entry 748======
 trtype:  loop
-subnqn:  blktests-subsystem-748
+subnqn:  blktests-subsystem-747
 =====Discovery Log Entry 749======
 trtype:  loop
-subnqn:  blktests-subsystem-749
+subnqn:  blktests-subsystem-748
 =====Discovery Log Entry 750======
 trtype:  loop
-subnqn:  blktests-subsystem-750
+subnqn:  blktests-subsystem-749
 =====Discovery Log Entry 751======
 trtype:  loop
-subnqn:  blktests-subsystem-751
+subnqn:  blktests-subsystem-750
 =====Discovery Log Entry 752======
 trtype:  loop
-subnqn:  blktests-subsystem-752
+subnqn:  blktests-subsystem-751
 =====Discovery Log Entry 753======
 trtype:  loop
-subnqn:  blktests-subsystem-753
+subnqn:  blktests-subsystem-752
 =====Discovery Log Entry 754======
 trtype:  loop
-subnqn:  blktests-subsystem-754
+subnqn:  blktests-subsystem-753
 =====Discovery Log Entry 755======
 trtype:  loop
-subnqn:  blktests-subsystem-755
+subnqn:  blktests-subsystem-754
 =====Discovery Log Entry 756======
 trtype:  loop
-subnqn:  blktests-subsystem-756
+subnqn:  blktests-subsystem-755
 =====Discovery Log Entry 757======
 trtype:  loop
-subnqn:  blktests-subsystem-757
+subnqn:  blktests-subsystem-756
 =====Discovery Log Entry 758======
 trtype:  loop
-subnqn:  blktests-subsystem-758
+subnqn:  blktests-subsystem-757
 =====Discovery Log Entry 759======
 trtype:  loop
-subnqn:  blktests-subsystem-759
+subnqn:  blktests-subsystem-758
 =====Discovery Log Entry 760======
 trtype:  loop
-subnqn:  blktests-subsystem-760
+subnqn:  blktests-subsystem-759
 =====Discovery Log Entry 761======
 trtype:  loop
-subnqn:  blktests-subsystem-761
+subnqn:  blktests-subsystem-760
 =====Discovery Log Entry 762======
 trtype:  loop
-subnqn:  blktests-subsystem-762
+subnqn:  blktests-subsystem-761
 =====Discovery Log Entry 763======
 trtype:  loop
-subnqn:  blktests-subsystem-763
+subnqn:  blktests-subsystem-762
 =====Discovery Log Entry 764======
 trtype:  loop
-subnqn:  blktests-subsystem-764
+subnqn:  blktests-subsystem-763
 =====Discovery Log Entry 765======
 trtype:  loop
-subnqn:  blktests-subsystem-765
+subnqn:  blktests-subsystem-764
 =====Discovery Log Entry 766======
 trtype:  loop
-subnqn:  blktests-subsystem-766
+subnqn:  blktests-subsystem-765
 =====Discovery Log Entry 767======
 trtype:  loop
-subnqn:  blktests-subsystem-767
+subnqn:  blktests-subsystem-766
 =====Discovery Log Entry 768======
 trtype:  loop
-subnqn:  blktests-subsystem-768
+subnqn:  blktests-subsystem-767
 =====Discovery Log Entry 769======
 trtype:  loop
-subnqn:  blktests-subsystem-769
+subnqn:  blktests-subsystem-768
 =====Discovery Log Entry 770======
 trtype:  loop
-subnqn:  blktests-subsystem-770
+subnqn:  blktests-subsystem-769
 =====Discovery Log Entry 771======
 trtype:  loop
-subnqn:  blktests-subsystem-771
+subnqn:  blktests-subsystem-770
 =====Discovery Log Entry 772======
 trtype:  loop
-subnqn:  blktests-subsystem-772
+subnqn:  blktests-subsystem-771
 =====Discovery Log Entry 773======
 trtype:  loop
-subnqn:  blktests-subsystem-773
+subnqn:  blktests-subsystem-772
 =====Discovery Log Entry 774======
 trtype:  loop
-subnqn:  blktests-subsystem-774
+subnqn:  blktests-subsystem-773
 =====Discovery Log Entry 775======
 trtype:  loop
-subnqn:  blktests-subsystem-775
+subnqn:  blktests-subsystem-774
 =====Discovery Log Entry 776======
 trtype:  loop
-subnqn:  blktests-subsystem-776
+subnqn:  blktests-subsystem-775
 =====Discovery Log Entry 777======
 trtype:  loop
-subnqn:  blktests-subsystem-777
+subnqn:  blktests-subsystem-776
 =====Discovery Log Entry 778======
 trtype:  loop
-subnqn:  blktests-subsystem-778
+subnqn:  blktests-subsystem-777
 =====Discovery Log Entry 779======
 trtype:  loop
-subnqn:  blktests-subsystem-779
+subnqn:  blktests-subsystem-778
 =====Discovery Log Entry 780======
 trtype:  loop
-subnqn:  blktests-subsystem-780
+subnqn:  blktests-subsystem-779
 =====Discovery Log Entry 781======
 trtype:  loop
-subnqn:  blktests-subsystem-781
+subnqn:  blktests-subsystem-780
 =====Discovery Log Entry 782======
 trtype:  loop
-subnqn:  blktests-subsystem-782
+subnqn:  blktests-subsystem-781
 =====Discovery Log Entry 783======
 trtype:  loop
-subnqn:  blktests-subsystem-783
+subnqn:  blktests-subsystem-782
 =====Discovery Log Entry 784======
 trtype:  loop
-subnqn:  blktests-subsystem-784
+subnqn:  blktests-subsystem-783
 =====Discovery Log Entry 785======
 trtype:  loop
-subnqn:  blktests-subsystem-785
+subnqn:  blktests-subsystem-784
 =====Discovery Log Entry 786======
 trtype:  loop
-subnqn:  blktests-subsystem-786
+subnqn:  blktests-subsystem-785
 =====Discovery Log Entry 787======
 trtype:  loop
-subnqn:  blktests-subsystem-787
+subnqn:  blktests-subsystem-786
 =====Discovery Log Entry 788======
 trtype:  loop
-subnqn:  blktests-subsystem-788
+subnqn:  blktests-subsystem-787
 =====Discovery Log Entry 789======
 trtype:  loop
-subnqn:  blktests-subsystem-789
+subnqn:  blktests-subsystem-788
 =====Discovery Log Entry 790======
 trtype:  loop
-subnqn:  blktests-subsystem-790
+subnqn:  blktests-subsystem-789
 =====Discovery Log Entry 791======
 trtype:  loop
-subnqn:  blktests-subsystem-791
+subnqn:  blktests-subsystem-790
 =====Discovery Log Entry 792======
 trtype:  loop
-subnqn:  blktests-subsystem-792
+subnqn:  blktests-subsystem-791
 =====Discovery Log Entry 793======
 trtype:  loop
-subnqn:  blktests-subsystem-793
+subnqn:  blktests-subsystem-792
 =====Discovery Log Entry 794======
 trtype:  loop
-subnqn:  blktests-subsystem-794
+subnqn:  blktests-subsystem-793
 =====Discovery Log Entry 795======
 trtype:  loop
-subnqn:  blktests-subsystem-795
+subnqn:  blktests-subsystem-794
 =====Discovery Log Entry 796======
 trtype:  loop
-subnqn:  blktests-subsystem-796
+subnqn:  blktests-subsystem-795
 =====Discovery Log Entry 797======
 trtype:  loop
-subnqn:  blktests-subsystem-797
+subnqn:  blktests-subsystem-796
 =====Discovery Log Entry 798======
 trtype:  loop
-subnqn:  blktests-subsystem-798
+subnqn:  blktests-subsystem-797
 =====Discovery Log Entry 799======
 trtype:  loop
-subnqn:  blktests-subsystem-799
+subnqn:  blktests-subsystem-798
 =====Discovery Log Entry 800======
 trtype:  loop
-subnqn:  blktests-subsystem-800
+subnqn:  blktests-subsystem-799
 =====Discovery Log Entry 801======
 trtype:  loop
-subnqn:  blktests-subsystem-801
+subnqn:  blktests-subsystem-800
 =====Discovery Log Entry 802======
 trtype:  loop
-subnqn:  blktests-subsystem-802
+subnqn:  blktests-subsystem-801
 =====Discovery Log Entry 803======
 trtype:  loop
-subnqn:  blktests-subsystem-803
+subnqn:  blktests-subsystem-802
 =====Discovery Log Entry 804======
 trtype:  loop
-subnqn:  blktests-subsystem-804
+subnqn:  blktests-subsystem-803
 =====Discovery Log Entry 805======
 trtype:  loop
-subnqn:  blktests-subsystem-805
+subnqn:  blktests-subsystem-804
 =====Discovery Log Entry 806======
 trtype:  loop
-subnqn:  blktests-subsystem-806
+subnqn:  blktests-subsystem-805
 =====Discovery Log Entry 807======
 trtype:  loop
-subnqn:  blktests-subsystem-807
+subnqn:  blktests-subsystem-806
 =====Discovery Log Entry 808======
 trtype:  loop
-subnqn:  blktests-subsystem-808
+subnqn:  blktests-subsystem-807
 =====Discovery Log Entry 809======
 trtype:  loop
-subnqn:  blktests-subsystem-809
+subnqn:  blktests-subsystem-808
 =====Discovery Log Entry 810======
 trtype:  loop
-subnqn:  blktests-subsystem-810
+subnqn:  blktests-subsystem-809
 =====Discovery Log Entry 811======
 trtype:  loop
-subnqn:  blktests-subsystem-811
+subnqn:  blktests-subsystem-810
 =====Discovery Log Entry 812======
 trtype:  loop
-subnqn:  blktests-subsystem-812
+subnqn:  blktests-subsystem-811
 =====Discovery Log Entry 813======
 trtype:  loop
-subnqn:  blktests-subsystem-813
+subnqn:  blktests-subsystem-812
 =====Discovery Log Entry 814======
 trtype:  loop
-subnqn:  blktests-subsystem-814
+subnqn:  blktests-subsystem-813
 =====Discovery Log Entry 815======
 trtype:  loop
-subnqn:  blktests-subsystem-815
+subnqn:  blktests-subsystem-814
 =====Discovery Log Entry 816======
 trtype:  loop
-subnqn:  blktests-subsystem-816
+subnqn:  blktests-subsystem-815
 =====Discovery Log Entry 817======
 trtype:  loop
-subnqn:  blktests-subsystem-817
+subnqn:  blktests-subsystem-816
 =====Discovery Log Entry 818======
 trtype:  loop
-subnqn:  blktests-subsystem-818
+subnqn:  blktests-subsystem-817
 =====Discovery Log Entry 819======
 trtype:  loop
-subnqn:  blktests-subsystem-819
+subnqn:  blktests-subsystem-818
 =====Discovery Log Entry 820======
 trtype:  loop
-subnqn:  blktests-subsystem-820
+subnqn:  blktests-subsystem-819
 =====Discovery Log Entry 821======
 trtype:  loop
-subnqn:  blktests-subsystem-821
+subnqn:  blktests-subsystem-820
 =====Discovery Log Entry 822======
 trtype:  loop
-subnqn:  blktests-subsystem-822
+subnqn:  blktests-subsystem-821
 =====Discovery Log Entry 823======
 trtype:  loop
-subnqn:  blktests-subsystem-823
+subnqn:  blktests-subsystem-822
 =====Discovery Log Entry 824======
 trtype:  loop
-subnqn:  blktests-subsystem-824
+subnqn:  blktests-subsystem-823
 =====Discovery Log Entry 825======
 trtype:  loop
-subnqn:  blktests-subsystem-825
+subnqn:  blktests-subsystem-824
 =====Discovery Log Entry 826======
 trtype:  loop
-subnqn:  blktests-subsystem-826
+subnqn:  blktests-subsystem-825
 =====Discovery Log Entry 827======
 trtype:  loop
-subnqn:  blktests-subsystem-827
+subnqn:  blktests-subsystem-826
 =====Discovery Log Entry 828======
 trtype:  loop
-subnqn:  blktests-subsystem-828
+subnqn:  blktests-subsystem-827
 =====Discovery Log Entry 829======
 trtype:  loop
-subnqn:  blktests-subsystem-829
+subnqn:  blktests-subsystem-828
 =====Discovery Log Entry 830======
 trtype:  loop
-subnqn:  blktests-subsystem-830
+subnqn:  blktests-subsystem-829
 =====Discovery Log Entry 831======
 trtype:  loop
-subnqn:  blktests-subsystem-831
+subnqn:  blktests-subsystem-830
 =====Discovery Log Entry 832======
 trtype:  loop
-subnqn:  blktests-subsystem-832
+subnqn:  blktests-subsystem-831
 =====Discovery Log Entry 833======
 trtype:  loop
-subnqn:  blktests-subsystem-833
+subnqn:  blktests-subsystem-832
 =====Discovery Log Entry 834======
 trtype:  loop
-subnqn:  blktests-subsystem-834
+subnqn:  blktests-subsystem-833
 =====Discovery Log Entry 835======
 trtype:  loop
-subnqn:  blktests-subsystem-835
+subnqn:  blktests-subsystem-834
 =====Discovery Log Entry 836======
 trtype:  loop
-subnqn:  blktests-subsystem-836
+subnqn:  blktests-subsystem-835
 =====Discovery Log Entry 837======
 trtype:  loop
-subnqn:  blktests-subsystem-837
+subnqn:  blktests-subsystem-836
 =====Discovery Log Entry 838======
 trtype:  loop
-subnqn:  blktests-subsystem-838
+subnqn:  blktests-subsystem-837
 =====Discovery Log Entry 839======
 trtype:  loop
-subnqn:  blktests-subsystem-839
+subnqn:  blktests-subsystem-838
 =====Discovery Log Entry 840======
 trtype:  loop
-subnqn:  blktests-subsystem-840
+subnqn:  blktests-subsystem-839
 =====Discovery Log Entry 841======
 trtype:  loop
-subnqn:  blktests-subsystem-841
+subnqn:  blktests-subsystem-840
 =====Discovery Log Entry 842======
 trtype:  loop
-subnqn:  blktests-subsystem-842
+subnqn:  blktests-subsystem-841
 =====Discovery Log Entry 843======
 trtype:  loop
-subnqn:  blktests-subsystem-843
+subnqn:  blktests-subsystem-842
 =====Discovery Log Entry 844======
 trtype:  loop
-subnqn:  blktests-subsystem-844
+subnqn:  blktests-subsystem-843
 =====Discovery Log Entry 845======
 trtype:  loop
-subnqn:  blktests-subsystem-845
+subnqn:  blktests-subsystem-844
 =====Discovery Log Entry 846======
 trtype:  loop
-subnqn:  blktests-subsystem-846
+subnqn:  blktests-subsystem-845
 =====Discovery Log Entry 847======
 trtype:  loop
-subnqn:  blktests-subsystem-847
+subnqn:  blktests-subsystem-846
 =====Discovery Log Entry 848======
 trtype:  loop
-subnqn:  blktests-subsystem-848
+subnqn:  blktests-subsystem-847
 =====Discovery Log Entry 849======
 trtype:  loop
-subnqn:  blktests-subsystem-849
+subnqn:  blktests-subsystem-848
 =====Discovery Log Entry 850======
 trtype:  loop
-subnqn:  blktests-subsystem-850
+subnqn:  blktests-subsystem-849
 =====Discovery Log Entry 851======
 trtype:  loop
-subnqn:  blktests-subsystem-851
+subnqn:  blktests-subsystem-850
 =====Discovery Log Entry 852======
 trtype:  loop
-subnqn:  blktests-subsystem-852
+subnqn:  blktests-subsystem-851
 =====Discovery Log Entry 853======
 trtype:  loop
-subnqn:  blktests-subsystem-853
+subnqn:  blktests-subsystem-852
 =====Discovery Log Entry 854======
 trtype:  loop
-subnqn:  blktests-subsystem-854
+subnqn:  blktests-subsystem-853
 =====Discovery Log Entry 855======
 trtype:  loop
-subnqn:  blktests-subsystem-855
+subnqn:  blktests-subsystem-854
 =====Discovery Log Entry 856======
 trtype:  loop
-subnqn:  blktests-subsystem-856
+subnqn:  blktests-subsystem-855
 =====Discovery Log Entry 857======
 trtype:  loop
-subnqn:  blktests-subsystem-857
+subnqn:  blktests-subsystem-856
 =====Discovery Log Entry 858======
 trtype:  loop
-subnqn:  blktests-subsystem-858
+subnqn:  blktests-subsystem-857
 =====Discovery Log Entry 859======
 trtype:  loop
-subnqn:  blktests-subsystem-859
+subnqn:  blktests-subsystem-858
 =====Discovery Log Entry 860======
 trtype:  loop
-subnqn:  blktests-subsystem-860
+subnqn:  blktests-subsystem-859
 =====Discovery Log Entry 861======
 trtype:  loop
-subnqn:  blktests-subsystem-861
+subnqn:  blktests-subsystem-860
 =====Discovery Log Entry 862======
 trtype:  loop
-subnqn:  blktests-subsystem-862
+subnqn:  blktests-subsystem-861
 =====Discovery Log Entry 863======
 trtype:  loop
-subnqn:  blktests-subsystem-863
+subnqn:  blktests-subsystem-862
 =====Discovery Log Entry 864======
 trtype:  loop
-subnqn:  blktests-subsystem-864
+subnqn:  blktests-subsystem-863
 =====Discovery Log Entry 865======
 trtype:  loop
-subnqn:  blktests-subsystem-865
+subnqn:  blktests-subsystem-864
 =====Discovery Log Entry 866======
 trtype:  loop
-subnqn:  blktests-subsystem-866
+subnqn:  blktests-subsystem-865
 =====Discovery Log Entry 867======
 trtype:  loop
-subnqn:  blktests-subsystem-867
+subnqn:  blktests-subsystem-866
 =====Discovery Log Entry 868======
 trtype:  loop
-subnqn:  blktests-subsystem-868
+subnqn:  blktests-subsystem-867
 =====Discovery Log Entry 869======
 trtype:  loop
-subnqn:  blktests-subsystem-869
+subnqn:  blktests-subsystem-868
 =====Discovery Log Entry 870======
 trtype:  loop
-subnqn:  blktests-subsystem-870
+subnqn:  blktests-subsystem-869
 =====Discovery Log Entry 871======
 trtype:  loop
-subnqn:  blktests-subsystem-871
+subnqn:  blktests-subsystem-870
 =====Discovery Log Entry 872======
 trtype:  loop
-subnqn:  blktests-subsystem-872
+subnqn:  blktests-subsystem-871
 =====Discovery Log Entry 873======
 trtype:  loop
-subnqn:  blktests-subsystem-873
+subnqn:  blktests-subsystem-872
 =====Discovery Log Entry 874======
 trtype:  loop
-subnqn:  blktests-subsystem-874
+subnqn:  blktests-subsystem-873
 =====Discovery Log Entry 875======
 trtype:  loop
-subnqn:  blktests-subsystem-875
+subnqn:  blktests-subsystem-874
 =====Discovery Log Entry 876======
 trtype:  loop
-subnqn:  blktests-subsystem-876
+subnqn:  blktests-subsystem-875
 =====Discovery Log Entry 877======
 trtype:  loop
-subnqn:  blktests-subsystem-877
+subnqn:  blktests-subsystem-876
 =====Discovery Log Entry 878======
 trtype:  loop
-subnqn:  blktests-subsystem-878
+subnqn:  blktests-subsystem-877
 =====Discovery Log Entry 879======
 trtype:  loop
-subnqn:  blktests-subsystem-879
+subnqn:  blktests-subsystem-878
 =====Discovery Log Entry 880======
 trtype:  loop
-subnqn:  blktests-subsystem-880
+subnqn:  blktests-subsystem-879
 =====Discovery Log Entry 881======
 trtype:  loop
-subnqn:  blktests-subsystem-881
+subnqn:  blktests-subsystem-880
 =====Discovery Log Entry 882======
 trtype:  loop
-subnqn:  blktests-subsystem-882
+subnqn:  blktests-subsystem-881
 =====Discovery Log Entry 883======
 trtype:  loop
-subnqn:  blktests-subsystem-883
+subnqn:  blktests-subsystem-882
 =====Discovery Log Entry 884======
 trtype:  loop
-subnqn:  blktests-subsystem-884
+subnqn:  blktests-subsystem-883
 =====Discovery Log Entry 885======
 trtype:  loop
-subnqn:  blktests-subsystem-885
+subnqn:  blktests-subsystem-884
 =====Discovery Log Entry 886======
 trtype:  loop
-subnqn:  blktests-subsystem-886
+subnqn:  blktests-subsystem-885
 =====Discovery Log Entry 887======
 trtype:  loop
-subnqn:  blktests-subsystem-887
+subnqn:  blktests-subsystem-886
 =====Discovery Log Entry 888======
 trtype:  loop
-subnqn:  blktests-subsystem-888
+subnqn:  blktests-subsystem-887
 =====Discovery Log Entry 889======
 trtype:  loop
-subnqn:  blktests-subsystem-889
+subnqn:  blktests-subsystem-888
 =====Discovery Log Entry 890======
 trtype:  loop
-subnqn:  blktests-subsystem-890
+subnqn:  blktests-subsystem-889
 =====Discovery Log Entry 891======
 trtype:  loop
-subnqn:  blktests-subsystem-891
+subnqn:  blktests-subsystem-890
 =====Discovery Log Entry 892======
 trtype:  loop
-subnqn:  blktests-subsystem-892
+subnqn:  blktests-subsystem-891
 =====Discovery Log Entry 893======
 trtype:  loop
-subnqn:  blktests-subsystem-893
+subnqn:  blktests-subsystem-892
 =====Discovery Log Entry 894======
 trtype:  loop
-subnqn:  blktests-subsystem-894
+subnqn:  blktests-subsystem-893
 =====Discovery Log Entry 895======
 trtype:  loop
-subnqn:  blktests-subsystem-895
+subnqn:  blktests-subsystem-894
 =====Discovery Log Entry 896======
 trtype:  loop
-subnqn:  blktests-subsystem-896
+subnqn:  blktests-subsystem-895
 =====Discovery Log Entry 897======
 trtype:  loop
-subnqn:  blktests-subsystem-897
+subnqn:  blktests-subsystem-896
 =====Discovery Log Entry 898======
 trtype:  loop
-subnqn:  blktests-subsystem-898
+subnqn:  blktests-subsystem-897
 =====Discovery Log Entry 899======
 trtype:  loop
-subnqn:  blktests-subsystem-899
+subnqn:  blktests-subsystem-898
 =====Discovery Log Entry 900======
 trtype:  loop
-subnqn:  blktests-subsystem-900
+subnqn:  blktests-subsystem-899
 =====Discovery Log Entry 901======
 trtype:  loop
-subnqn:  blktests-subsystem-901
+subnqn:  blktests-subsystem-900
 =====Discovery Log Entry 902======
 trtype:  loop
-subnqn:  blktests-subsystem-902
+subnqn:  blktests-subsystem-901
 =====Discovery Log Entry 903======
 trtype:  loop
-subnqn:  blktests-subsystem-903
+subnqn:  blktests-subsystem-902
 =====Discovery Log Entry 904======
 trtype:  loop
-subnqn:  blktests-subsystem-904
+subnqn:  blktests-subsystem-903
 =====Discovery Log Entry 905======
 trtype:  loop
-subnqn:  blktests-subsystem-905
+subnqn:  blktests-subsystem-904
 =====Discovery Log Entry 906======
 trtype:  loop
-subnqn:  blktests-subsystem-906
+subnqn:  blktests-subsystem-905
 =====Discovery Log Entry 907======
 trtype:  loop
-subnqn:  blktests-subsystem-907
+subnqn:  blktests-subsystem-906
 =====Discovery Log Entry 908======
 trtype:  loop
-subnqn:  blktests-subsystem-908
+subnqn:  blktests-subsystem-907
 =====Discovery Log Entry 909======
 trtype:  loop
-subnqn:  blktests-subsystem-909
+subnqn:  blktests-subsystem-908
 =====Discovery Log Entry 910======
 trtype:  loop
-subnqn:  blktests-subsystem-910
+subnqn:  blktests-subsystem-909
 =====Discovery Log Entry 911======
 trtype:  loop
-subnqn:  blktests-subsystem-911
+subnqn:  blktests-subsystem-910
 =====Discovery Log Entry 912======
 trtype:  loop
-subnqn:  blktests-subsystem-912
+subnqn:  blktests-subsystem-911
 =====Discovery Log Entry 913======
 trtype:  loop
-subnqn:  blktests-subsystem-913
+subnqn:  blktests-subsystem-912
 =====Discovery Log Entry 914======
 trtype:  loop
-subnqn:  blktests-subsystem-914
+subnqn:  blktests-subsystem-913
 =====Discovery Log Entry 915======
 trtype:  loop
-subnqn:  blktests-subsystem-915
+subnqn:  blktests-subsystem-914
 =====Discovery Log Entry 916======
 trtype:  loop
-subnqn:  blktests-subsystem-916
+subnqn:  blktests-subsystem-915
 =====Discovery Log Entry 917======
 trtype:  loop
-subnqn:  blktests-subsystem-917
+subnqn:  blktests-subsystem-916
 =====Discovery Log Entry 918======
 trtype:  loop
-subnqn:  blktests-subsystem-918
+subnqn:  blktests-subsystem-917
 =====Discovery Log Entry 919======
 trtype:  loop
-subnqn:  blktests-subsystem-919
+subnqn:  blktests-subsystem-918
 =====Discovery Log Entry 920======
 trtype:  loop
-subnqn:  blktests-subsystem-920
+subnqn:  blktests-subsystem-919
 =====Discovery Log Entry 921======
 trtype:  loop
-subnqn:  blktests-subsystem-921
+subnqn:  blktests-subsystem-920
 =====Discovery Log Entry 922======
 trtype:  loop
-subnqn:  blktests-subsystem-922
+subnqn:  blktests-subsystem-921
 =====Discovery Log Entry 923======
 trtype:  loop
-subnqn:  blktests-subsystem-923
+subnqn:  blktests-subsystem-922
 =====Discovery Log Entry 924======
 trtype:  loop
-subnqn:  blktests-subsystem-924
+subnqn:  blktests-subsystem-923
 =====Discovery Log Entry 925======
 trtype:  loop
-subnqn:  blktests-subsystem-925
+subnqn:  blktests-subsystem-924
 =====Discovery Log Entry 926======
 trtype:  loop
-subnqn:  blktests-subsystem-926
+subnqn:  blktests-subsystem-925
 =====Discovery Log Entry 927======
 trtype:  loop
-subnqn:  blktests-subsystem-927
+subnqn:  blktests-subsystem-926
 =====Discovery Log Entry 928======
 trtype:  loop
-subnqn:  blktests-subsystem-928
+subnqn:  blktests-subsystem-927
 =====Discovery Log Entry 929======
 trtype:  loop
-subnqn:  blktests-subsystem-929
+subnqn:  blktests-subsystem-928
 =====Discovery Log Entry 930======
 trtype:  loop
-subnqn:  blktests-subsystem-930
+subnqn:  blktests-subsystem-929
 =====Discovery Log Entry 931======
 trtype:  loop
-subnqn:  blktests-subsystem-931
+subnqn:  blktests-subsystem-930
 =====Discovery Log Entry 932======
 trtype:  loop
-subnqn:  blktests-subsystem-932
+subnqn:  blktests-subsystem-931
 =====Discovery Log Entry 933======
 trtype:  loop
-subnqn:  blktests-subsystem-933
+subnqn:  blktests-subsystem-932
 =====Discovery Log Entry 934======
 trtype:  loop
-subnqn:  blktests-subsystem-934
+subnqn:  blktests-subsystem-933
 =====Discovery Log Entry 935======
 trtype:  loop
-subnqn:  blktests-subsystem-935
+subnqn:  blktests-subsystem-934
 =====Discovery Log Entry 936======
 trtype:  loop
-subnqn:  blktests-subsystem-936
+subnqn:  blktests-subsystem-935
 =====Discovery Log Entry 937======
 trtype:  loop
-subnqn:  blktests-subsystem-937
+subnqn:  blktests-subsystem-936
 =====Discovery Log Entry 938======
 trtype:  loop
-subnqn:  blktests-subsystem-938
+subnqn:  blktests-subsystem-937
 =====Discovery Log Entry 939======
 trtype:  loop
-subnqn:  blktests-subsystem-939
+subnqn:  blktests-subsystem-938
 =====Discovery Log Entry 940======
 trtype:  loop
-subnqn:  blktests-subsystem-940
+subnqn:  blktests-subsystem-939
 =====Discovery Log Entry 941======
 trtype:  loop
-subnqn:  blktests-subsystem-941
+subnqn:  blktests-subsystem-940
 =====Discovery Log Entry 942======
 trtype:  loop
-subnqn:  blktests-subsystem-942
+subnqn:  blktests-subsystem-941
 =====Discovery Log Entry 943======
 trtype:  loop
-subnqn:  blktests-subsystem-943
+subnqn:  blktests-subsystem-942
 =====Discovery Log Entry 944======
 trtype:  loop
-subnqn:  blktests-subsystem-944
+subnqn:  blktests-subsystem-943
 =====Discovery Log Entry 945======
 trtype:  loop
-subnqn:  blktests-subsystem-945
+subnqn:  blktests-subsystem-944
 =====Discovery Log Entry 946======
 trtype:  loop
-subnqn:  blktests-subsystem-946
+subnqn:  blktests-subsystem-945
 =====Discovery Log Entry 947======
 trtype:  loop
-subnqn:  blktests-subsystem-947
+subnqn:  blktests-subsystem-946
 =====Discovery Log Entry 948======
 trtype:  loop
-subnqn:  blktests-subsystem-948
+subnqn:  blktests-subsystem-947
 =====Discovery Log Entry 949======
 trtype:  loop
-subnqn:  blktests-subsystem-949
+subnqn:  blktests-subsystem-948
 =====Discovery Log Entry 950======
 trtype:  loop
-subnqn:  blktests-subsystem-950
+subnqn:  blktests-subsystem-949
 =====Discovery Log Entry 951======
 trtype:  loop
-subnqn:  blktests-subsystem-951
+subnqn:  blktests-subsystem-950
 =====Discovery Log Entry 952======
 trtype:  loop
-subnqn:  blktests-subsystem-952
+subnqn:  blktests-subsystem-951
 =====Discovery Log Entry 953======
 trtype:  loop
-subnqn:  blktests-subsystem-953
+subnqn:  blktests-subsystem-952
 =====Discovery Log Entry 954======
 trtype:  loop
-subnqn:  blktests-subsystem-954
+subnqn:  blktests-subsystem-953
 =====Discovery Log Entry 955======
 trtype:  loop
-subnqn:  blktests-subsystem-955
+subnqn:  blktests-subsystem-954
 =====Discovery Log Entry 956======
 trtype:  loop
-subnqn:  blktests-subsystem-956
+subnqn:  blktests-subsystem-955
 =====Discovery Log Entry 957======
 trtype:  loop
-subnqn:  blktests-subsystem-957
+subnqn:  blktests-subsystem-956
 =====Discovery Log Entry 958======
 trtype:  loop
-subnqn:  blktests-subsystem-958
+subnqn:  blktests-subsystem-957
 =====Discovery Log Entry 959======
 trtype:  loop
-subnqn:  blktests-subsystem-959
+subnqn:  blktests-subsystem-958
 =====Discovery Log Entry 960======
 trtype:  loop
-subnqn:  blktests-subsystem-960
+subnqn:  blktests-subsystem-959
 =====Discovery Log Entry 961======
 trtype:  loop
-subnqn:  blktests-subsystem-961
+subnqn:  blktests-subsystem-960
 =====Discovery Log Entry 962======
 trtype:  loop
-subnqn:  blktests-subsystem-962
+subnqn:  blktests-subsystem-961
 =====Discovery Log Entry 963======
 trtype:  loop
-subnqn:  blktests-subsystem-963
+subnqn:  blktests-subsystem-962
 =====Discovery Log Entry 964======
 trtype:  loop
-subnqn:  blktests-subsystem-964
+subnqn:  blktests-subsystem-963
 =====Discovery Log Entry 965======
 trtype:  loop
-subnqn:  blktests-subsystem-965
+subnqn:  blktests-subsystem-964
 =====Discovery Log Entry 966======
 trtype:  loop
-subnqn:  blktests-subsystem-966
+subnqn:  blktests-subsystem-965
 =====Discovery Log Entry 967======
 trtype:  loop
-subnqn:  blktests-subsystem-967
+subnqn:  blktests-subsystem-966
 =====Discovery Log Entry 968======
 trtype:  loop
-subnqn:  blktests-subsystem-968
+subnqn:  blktests-subsystem-967
 =====Discovery Log Entry 969======
 trtype:  loop
-subnqn:  blktests-subsystem-969
+subnqn:  blktests-subsystem-968
 =====Discovery Log Entry 970======
 trtype:  loop
-subnqn:  blktests-subsystem-970
+subnqn:  blktests-subsystem-969
 =====Discovery Log Entry 971======
 trtype:  loop
-subnqn:  blktests-subsystem-971
+subnqn:  blktests-subsystem-970
 =====Discovery Log Entry 972======
 trtype:  loop
-subnqn:  blktests-subsystem-972
+subnqn:  blktests-subsystem-971
 =====Discovery Log Entry 973======
 trtype:  loop
-subnqn:  blktests-subsystem-973
+subnqn:  blktests-subsystem-972
 =====Discovery Log Entry 974======
 trtype:  loop
-subnqn:  blktests-subsystem-974
+subnqn:  blktests-subsystem-973
 =====Discovery Log Entry 975======
 trtype:  loop
-subnqn:  blktests-subsystem-975
+subnqn:  blktests-subsystem-974
 =====Discovery Log Entry 976======
 trtype:  loop
-subnqn:  blktests-subsystem-976
+subnqn:  blktests-subsystem-975
 =====Discovery Log Entry 977======
 trtype:  loop
-subnqn:  blktests-subsystem-977
+subnqn:  blktests-subsystem-976
 =====Discovery Log Entry 978======
 trtype:  loop
-subnqn:  blktests-subsystem-978
+subnqn:  blktests-subsystem-977
 =====Discovery Log Entry 979======
 trtype:  loop
-subnqn:  blktests-subsystem-979
+subnqn:  blktests-subsystem-978
 =====Discovery Log Entry 980======
 trtype:  loop
-subnqn:  blktests-subsystem-980
+subnqn:  blktests-subsystem-979
 =====Discovery Log Entry 981======
 trtype:  loop
-subnqn:  blktests-subsystem-981
+subnqn:  blktests-subsystem-980
 =====Discovery Log Entry 982======
 trtype:  loop
-subnqn:  blktests-subsystem-982
+subnqn:  blktests-subsystem-981
 =====Discovery Log Entry 983======
 trtype:  loop
-subnqn:  blktests-subsystem-983
+subnqn:  blktests-subsystem-982
 =====Discovery Log Entry 984======
 trtype:  loop
-subnqn:  blktests-subsystem-984
+subnqn:  blktests-subsystem-983
 =====Discovery Log Entry 985======
 trtype:  loop
-subnqn:  blktests-subsystem-985
+subnqn:  blktests-subsystem-984
 =====Discovery Log Entry 986======
 trtype:  loop
-subnqn:  blktests-subsystem-986
+subnqn:  blktests-subsystem-985
 =====Discovery Log Entry 987======
 trtype:  loop
-subnqn:  blktests-subsystem-987
+subnqn:  blktests-subsystem-986
 =====Discovery Log Entry 988======
 trtype:  loop
-subnqn:  blktests-subsystem-988
+subnqn:  blktests-subsystem-987
 =====Discovery Log Entry 989======
 trtype:  loop
-subnqn:  blktests-subsystem-989
+subnqn:  blktests-subsystem-988
 =====Discovery Log Entry 990======
 trtype:  loop
-subnqn:  blktests-subsystem-990
+subnqn:  blktests-subsystem-989
 =====Discovery Log Entry 991======
 trtype:  loop
-subnqn:  blktests-subsystem-991
+subnqn:  blktests-subsystem-990
 =====Discovery Log Entry 992======
 trtype:  loop
-subnqn:  blktests-subsystem-992
+subnqn:  blktests-subsystem-991
 =====Discovery Log Entry 993======
 trtype:  loop
-subnqn:  blktests-subsystem-993
+subnqn:  blktests-subsystem-992
 =====Discovery Log Entry 994======
 trtype:  loop
-subnqn:  blktests-subsystem-994
+subnqn:  blktests-subsystem-993
 =====Discovery Log Entry 995======
 trtype:  loop
-subnqn:  blktests-subsystem-995
+subnqn:  blktests-subsystem-994
 =====Discovery Log Entry 996======
 trtype:  loop
-subnqn:  blktests-subsystem-996
+subnqn:  blktests-subsystem-995
 =====Discovery Log Entry 997======
 trtype:  loop
-subnqn:  blktests-subsystem-997
+subnqn:  blktests-subsystem-996
 =====Discovery Log Entry 998======
 trtype:  loop
-subnqn:  blktests-subsystem-998
+subnqn:  blktests-subsystem-997
 =====Discovery Log Entry 999======
+trtype:  loop
+subnqn:  blktests-subsystem-998
+=====Discovery Log Entry 1000======
 trtype:  loop
 subnqn:  blktests-subsystem-999
 Test complete

--- a/tests/nvme/016.out
+++ b/tests/nvme/016.out
@@ -1,6 +1,9 @@
 Running nvme/016
-Discovery Log Number of Records 1, Generation counter X
+Discovery Log Number of Records 2, Generation counter X
 =====Discovery Log Entry 0======
+trtype:  loop
+subnqn:  nqn.2014-08.org.nvmexpress.discovery
+=====Discovery Log Entry 1======
 trtype:  loop
 subnqn:  blktests-subsystem-1
 Test complete

--- a/tests/nvme/017.out
+++ b/tests/nvme/017.out
@@ -1,6 +1,9 @@
 Running nvme/017
-Discovery Log Number of Records 1, Generation counter X
+Discovery Log Number of Records 2, Generation counter X
 =====Discovery Log Entry 0======
+trtype:  loop
+subnqn:  nqn.2014-08.org.nvmexpress.discovery
+=====Discovery Log Entry 1======
 trtype:  loop
 subnqn:  blktests-subsystem-1
 Test complete


### PR DESCRIPTION
With TP8013 the discovery log includes now a record for the discovery subsystem itself, so we need to update the blktests to be aware of the new discovery log page layout.

Signed-off-by: Hannes Reinecke <hare@suse.de>