### PR TITLE
Add test for ANA support

### DIFF
--- a/tests/nvme/046
+++ b/tests/nvme/046
@@ -1,0 +1,178 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0+
+# Copyright (C) 2023 Hannes Reinecke, SUSE Labs
+#
+# Regression test for ANA base support
+
+. tests/nvme/rc
+. common/xfs
+
+DESCRIPTION="test ANA optimized/transitioning/inaccessible support"
+
+requires() {
+	_nvme_requires
+	_have_loop
+	_have_xfs
+	_have_fio
+	_require_nvme_trtype_is_fabrics
+}
+
+switch_nvmet_anagroup() {
+	local port1="$1"
+	local port2="$2"
+	local mode="$3"
+
+	echo "ANA state ${mode}"
+
+	if [ "${mode}" = "change" ] ; then
+		_set_nvmet_anagroup_state "${port1}" "1" "change"
+		_set_nvmet_anagroup_state "${port1}" "2" "change"
+		_set_nvmet_anagroup_state "${port2}" "1" "change"
+		_set_nvmet_anagroup_state "${port2}" "2" "change"
+	elif [ "${mode}" = "failover" ] ; then
+		_set_nvmet_anagroup_state "${port1}" "1" "inaccessible"
+		_set_nvmet_anagroup_state "${port1}" "2" "optimized"
+		_set_nvmet_anagroup_state "${port2}" "1" "optimized"
+		_set_nvmet_anagroup_state "${port2}" "2" "inaccessible"
+	elif [ "${mode}" = "soft-failover" ] ; then
+		_set_nvmet_anagroup_state "${port1}" "1" "non-optimized"
+		_set_nvmet_anagroup_state "${port1}" "2" "optimized"
+		_set_nvmet_anagroup_state "${port2}" "1" "optimized"
+		_set_nvmet_anagroup_state "${port2}" "2" "non-optimized"
+	elif [ "${mode}" = "soft-failback" ] ; then
+		_set_nvmet_anagroup_state "${port1}" "1" "optimized"
+		_set_nvmet_anagroup_state "${port1}" "2" "non-optimized"
+		_set_nvmet_anagroup_state "${port2}" "1" "non-optimized"
+		_set_nvmet_anagroup_state "${port2}" "2" "optimized"
+	else
+		_set_nvmet_anagroup_state "${port1}" "1" "optimized"
+		_set_nvmet_anagroup_state "${port1}" "2" "inaccessible"
+		_set_nvmet_anagroup_state "${port2}" "1" "inaccessible"
+		_set_nvmet_anagroup_state "${port2}" "2" "optimized"
+	fi
+}
+
+execute_ana_test() {
+	local nvmedev=$1
+	local subsys_name=$2
+	local port1=$3
+	local port2=$4
+	local mount_dir="/mnt/blktests"
+
+	_xfs_mkfs_and_mount "/dev/${nvmedev}n1" "${mount_dir}" > /dev/null 2>&1
+
+	_run_fio_rand_io --size=64m --directory="${mount_dir}" \
+			 --runtime=20s --time_based &
+	trap 'kill %1' EXIT
+
+	switch_nvmet_anagroup "${port1}" "${port2}" "failover"
+
+	# Insert a delay to allow the AEN to be processed
+	sleep 1
+
+	_display_ana_state "${subsys_name}"
+
+	sleep 3
+
+	switch_nvmet_anagroup "${port1}" "${port2}" "change"
+
+	# Insert a delay to allow the AEN to be processed
+	sleep 1
+
+	_display_ana_state "${subsys_name}"
+
+	sleep 1
+
+	switch_nvmet_anagroup "${port1}" "${port2}" "failback"
+
+	# Insert a delay to allow the AEN to be processed
+	sleep 1
+
+	_display_ana_state "${subsys_name}"
+
+	sleep 3
+
+	switch_nvmet_anagroup "${port1}" "${port2}" "soft-failover"
+
+	# Insert a delay to allow the AEN to be processed
+	sleep 1
+
+	_display_ana_state "${subsys_name}"
+
+	sleep 3
+
+	switch_nvmet_anagroup "${port1}" "${port2}" "soft-failback"
+
+	# Insert a delay to allow the AEN to be processed
+	sleep 1
+
+	_display_ana_state "${subsys_name}"
+
+	wait
+	trap - EXIT
+
+	umount "${mount_dir}" > /dev/null 2>&1
+	rmdir "${mount_dir}"
+}
+
+test() {
+	local port1
+	local port2
+	local subsys_name="blktests-subsystem-1"
+	local file_path1="${TMPDIR}/img1"
+	local file_path2="${TMPDIR}/img2"
+	local loop_dev1
+	local loop_dev2
+	local nvmedev
+
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
+	_create_nvmet_subsystem "${subsys_name}"
+
+	port1="$(_create_nvmet_port "${nvme_trtype}")"
+	_create_nvmet_anagroup "${port1}" > /dev/null
+
+	truncate -s 512M "${file_path1}"
+	loop_dev1="$(losetup -f --show "${file_path1}")"
+
+	_create_nvmet_ns "${subsys_name}" "1" "${loop_dev1}" "1"
+
+	port2="$(_create_nvmet_port "${nvme_trtype}")"
+	_create_nvmet_anagroup "${port2}" > /dev/null
+
+	truncate -s 512M "${file_path2}"
+	loop_dev2="$(losetup -f --show "${file_path2}")"
+
+	_create_nvmet_ns "${subsys_name}" "2" "${loop_dev2}" "2"
+
+	_add_nvmet_subsys_to_port "${port1}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port2}" "${subsys_name}"
+
+	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" "${port1}"
+	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" "${port2}"
+
+	udevadm settle
+
+	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	if [[ -n "${nvmedev}" ]]; then
+		execute_ana_test "${nvmedev}" "${subsys_name}" \
+				 "${port1}" "${port2}"
+	fi
+
+	nvme disconnect -n "${subsys_name}"
+
+	_remove_nvmet_subsystem_from_port "${port1}" "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port2}" "${subsys_name}"
+	_remove_nvmet_ns "${subsys_name}" "2"
+	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_port "${port1}"
+	_remove_nvmet_port "${port2}"
+	losetup --detach "${loop_dev2}"
+	rm "${file_path2}"
+	losetup --detach "${loop_dev1}"
+	rm "${file_path1}"
+
+	echo "Test complete"
+}

--- a/tests/nvme/046.out
+++ b/tests/nvme/046.out
@@ -1,0 +1,28 @@
+Running nvme/046
+ANA state failover
+1: grpid 1 state inaccessible
+1: grpid 2 state optimized
+2: grpid 1 state optimized
+2: grpid 2 state inaccessible
+ANA state change
+1: grpid 1 state change
+1: grpid 2 state change
+2: grpid 1 state change
+2: grpid 2 state change
+ANA state failback
+1: grpid 1 state optimized
+1: grpid 2 state inaccessible
+2: grpid 1 state inaccessible
+2: grpid 2 state optimized
+ANA state soft-failover
+1: grpid 1 state non-optimized
+1: grpid 2 state optimized
+2: grpid 1 state optimized
+2: grpid 2 state non-optimized
+ANA state soft-failback
+1: grpid 1 state optimized
+1: grpid 2 state non-optimized
+2: grpid 1 state non-optimized
+2: grpid 2 state optimized
+NQN:blktests-subsystem-1 disconnected 2 controller(s)
+Test complete

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -229,8 +229,7 @@ _cleanup_nvmet() {
 	for port in "${NVMET_CFS}"/ports/*; do
 		name=$(basename "${port}")
 		echo "WARNING: Test did not clean up port: ${name}"
-		rm -f "${port}"/subsystems/*
-		rmdir "${port}"
+		_remove_nvmet_port "${name}"
 	done
 
 	for subsys in "${NVMET_CFS}"/subsystems/*; do
@@ -388,7 +387,63 @@ _create_nvmet_port() {
 
 _remove_nvmet_port() {
 	local port="$1"
-	rmdir "${NVMET_CFS}/ports/${port}"
+	local port_cfs="${NVMET_CFS}/ports/${port}"
+	for grp in "${port_cfs}"/ana_groups/*; do
+		[ -d "${grp}" ] || continue
+		if [[ "${grp##*/}" != "1" ]]; then
+			rmdir "${grp}"
+		fi
+	done
+	rm -f "${port_cfs}"/subsystems/*
+	rmdir "${port_cfs}"
+}
+
+_create_nvmet_anagroup() {
+	local port="$1"
+	local port_cfs="${NVMET_CFS}/ports/${port}"
+	local grpid
+
+	for ((grpid = 1; ; grpid++)); do
+		if [[ ! -e "${port_cfs}/ana_groups/${grpid}" ]]; then
+			break
+		fi
+	done
+
+	mkdir "${port_cfs}/ana_groups/${grpid}"
+
+	echo "${grpid}"
+}
+
+_set_nvmet_anagroup_state() {
+	local port="$1"
+	local grpid="$2"
+	local state="$3"
+	local ana_cfs="${NVMET_CFS}/ports/${port}/ana_groups/${grpid}"
+
+	echo "${state}" > "${ana_cfs}/ana_state"
+}
+
+_display_ana_state() {
+	local nvmet_subsystem="$1"
+	local grpid state cntlid
+
+	for nvme in /sys/class/nvme/* ; do
+		[ -f ${nvme}/subsysnqn ] || continue
+		subsys="$(cat "${nvme}/subsysnqn")"
+		if [ "${subsys}" != "${nvmet_subsystem}" ] ; then
+			continue
+		fi
+		cntlid="$(cat "${nvme}/cntlid")"
+		for c in ${nvme}/nvme* ; do
+			if [ ! -d ${c} ] ; then
+				echo "${cntlid}: ANA disabled"
+				continue
+			fi
+			grpid="$(cat "${c}/ana_grpid")"
+			state="$(cat "${c}/ana_state")"
+			echo "${cntlid}: grpid ${grpid} state ${state}"
+		done
+	done
 }
 
 _create_nvmet_ns() {
@@ -398,26 +453,48 @@ _create_nvmet_ns() {
 	local uuid="00000000-0000-0000-0000-000000000000"
 	local subsys_path="${NVMET_CFS}/subsystems/${nvmet_subsystem}"
 	local ns_path="${subsys_path}/namespaces/${nsid}"
+	local ana_grpid
 
 	if [[ $# -eq 4 ]]; then
-		uuid="$4"
+		ana_grpid="$4"
+	fi
+
+	if [[ $# -ge 5 ]]; then
+		uuid="$5"
 	fi
 
 	mkdir "${ns_path}"
 	printf "%s" "${blkdev}" > "${ns_path}/device_path"
 	printf "%s" "${uuid}" > "${ns_path}/device_uuid"
+	if [ -n "${ana_grpid}" ] ; then
+		printf "%s" "${ana_grpid}" > "${ns_path}/ana_grpid"
+	fi
 	printf 1 > "${ns_path}/enable"
 }
 
 _create_nvmet_subsystem() {
 	local nvmet_subsystem="$1"
-	local blkdev="$2"
-	local uuid=$3
+	local blkdev
+	local uuid
+	local ana_grpid
 	local cfs_path="${NVMET_CFS}/subsystems/${nvmet_subsystem}"
 
 	mkdir -p "${cfs_path}"
 	echo 1 > "${cfs_path}/attr_allow_any_host"
-	_create_nvmet_ns "${nvmet_subsystem}" "1" "${blkdev}" "${uuid}"
+	if [[ $# -ge 2 ]]; then
+		blkdev="$2"
+	fi
+	if [[ $# -ge 3 ]]; then
+		uuid="$3"
+	fi
+	if [[ $# -ge 4 ]]; then
+		ana_grpid="$4"
+	fi
+	if [ -z "$blkdev" ]; then
+		return
+	fi
+	_create_nvmet_ns "${nvmet_subsystem}" "1" "${blkdev}" \
+			"${uuid}" "${ana_grpid}"
 }
 
 _create_nvmet_host() {
@@ -548,8 +625,11 @@ _find_nvme_dev() {
 		[ -e "$dev" ] || continue
 		dev="$(basename "$dev")"
 		subsysnqn="$(cat "/sys/class/nvme/${dev}/subsysnqn")"
-		if [[ "$subsysnqn" == "$subsys" ]]; then
+		if [[ "${subsysnqn}" == "${subsys}" ]]; then
 			echo "$dev"
+			if [[ ! -d /sys/block/${dev} ]] ; then
+				return
+			fi
 			for ((i = 0; i < 10; i++)); do
 				if [[ -e /sys/block/$dev/uuid &&
 					-e /sys/block/$dev/wwid ]]; then


### PR DESCRIPTION
This small patchset adds a test for ANA support.

NOTE: there seems to be a bug in the kernel which doesn't align the ANA groups correctly with the paths; the 'out' file displays the output as it _should_ be (and which matches the settings from nvmet). But the output from sysfs seems to have issues matching group ids to paths.
Investigating.