### PR TITLE
nvme/rc: Avoid triggering host nvme-cli autoconnect

### DIFF
--- a/tests/nvme/003
+++ b/tests/nvme/003
@@ -29,8 +29,8 @@ test() {
 
 	loop_dev="$(losetup -f)"
 
-	_create_nvmet_subsystem "blktests-subsystem-1" "${loop_dev}"
-	_add_nvmet_subsys_to_port "${port}" "blktests-subsystem-1"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" nqn.2014-08.org.nvmexpress.discovery
 
@@ -46,8 +46,8 @@ test() {
 	fi
 
 	_nvme_disconnect_subsys nqn.2014-08.org.nvmexpress.discovery
-	_remove_nvmet_subsystem_from_port "${port}" "blktests-subsystem-1"
-	_remove_nvmet_subsystem "blktests-subsystem-1"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	echo "Test complete"

--- a/tests/nvme/003
+++ b/tests/nvme/003
@@ -22,10 +22,11 @@ test() {
 
 	_setup_nvmet
 
+	local loop_dev
 	local port
+
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
-	local loop_dev
 	loop_dev="$(losetup -f)"
 
 	_create_nvmet_subsystem "blktests-subsystem-1" "${loop_dev}"

--- a/tests/nvme/003
+++ b/tests/nvme/003
@@ -22,15 +22,9 @@ test() {
 
 	_setup_nvmet
 
-	local loop_dev
 	local port
 
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-
-	loop_dev="$(losetup -f)"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" nqn.2014-08.org.nvmexpress.discovery
 
@@ -46,9 +40,8 @@ test() {
 	fi
 
 	_nvme_disconnect_subsys nqn.2014-08.org.nvmexpress.discovery
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
+
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/004
+++ b/tests/nvme/004
@@ -23,11 +23,12 @@ test() {
 	_setup_nvmet
 
 	local port
+	local loop_dev
+
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
 	truncate -s "${nvme_img_size}" "$TMPDIR/img"
 
-	local loop_dev
 	loop_dev="$(losetup -f --show "$TMPDIR/img")"
 
 	_create_nvmet_subsystem "blktests-subsystem-1" "${loop_dev}" \

--- a/tests/nvme/004
+++ b/tests/nvme/004
@@ -27,9 +27,9 @@ test() {
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
-	truncate -s "${nvme_img_size}" "$TMPDIR/img"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "$TMPDIR/img")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -47,7 +47,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 	losetup -d "$loop_dev"
-	rm "$TMPDIR/img"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/004
+++ b/tests/nvme/004
@@ -23,18 +23,8 @@ test() {
 	_setup_nvmet
 
 	local port
-	local loop_dev
 
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,12 +34,8 @@ test() {
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	_nvme_disconnect_subsys ${def_subsysnqn}
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-	losetup -d "$loop_dev"
-	rm "${def_file_path}"
+
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/004
+++ b/tests/nvme/004
@@ -34,6 +34,7 @@ test() {
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"${def_subsys_uuid}"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -46,6 +47,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 	losetup -d "$loop_dev"
 	rm "${def_file_path}"
 

--- a/tests/nvme/004
+++ b/tests/nvme/004
@@ -32,7 +32,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"

--- a/tests/nvme/004
+++ b/tests/nvme/004
@@ -31,20 +31,20 @@ test() {
 
 	loop_dev="$(losetup -f --show "$TMPDIR/img")"
 
-	_create_nvmet_subsystem "blktests-subsystem-1" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
-	_add_nvmet_subsys_to_port "${port}" "blktests-subsystem-1"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" blktests-subsystem-1
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	local nvmedev
-	nvmedev=$(_find_nvme_dev "blktests-subsystem-1")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
-	_nvme_disconnect_subsys blktests-subsystem-1
-	_remove_nvmet_subsystem_from_port "${port}" "blktests-subsystem-1"
-	_remove_nvmet_subsystem "blktests-subsystem-1"
+	_nvme_disconnect_subsys ${def_subsysnqn}
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 	losetup -d "$loop_dev"
 	rm "$TMPDIR/img"

--- a/tests/nvme/005
+++ b/tests/nvme/005
@@ -22,11 +22,13 @@ test() {
 	_setup_nvmet
 
 	local port
+	local loop_dev
+	local nvmedev
+
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
 	truncate -s "${nvme_img_size}" "$TMPDIR/img"
 
-	local loop_dev
 	loop_dev="$(losetup -f --show "$TMPDIR/img")"
 
 	_create_nvmet_subsystem "blktests-subsystem-1" "${loop_dev}" \
@@ -35,7 +37,6 @@ test() {
 
 	_nvme_connect_subsys "${nvme_trtype}" blktests-subsystem-1
 
-	local nvmedev
 	nvmedev=$(_find_nvme_dev "blktests-subsystem-1")
 
 	udevadm settle

--- a/tests/nvme/005
+++ b/tests/nvme/005
@@ -27,9 +27,9 @@ test() {
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
-	truncate -s "${nvme_img_size}" "$TMPDIR/img"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "$TMPDIR/img")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -49,7 +49,7 @@ test() {
 
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	losetup -d "$loop_dev"
-	rm "$TMPDIR/img"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/005
+++ b/tests/nvme/005
@@ -22,19 +22,9 @@ test() {
 	_setup_nvmet
 
 	local port
-	local loop_dev
 	local nvmedev
 
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -45,13 +35,8 @@ test() {
 	echo 1 > "/sys/class/nvme/${nvmedev}/reset_controller"
 
 	_nvme_disconnect_ctrl "${nvmedev}"
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_host "${def_hostnqn}"
 
-	losetup -d "$loop_dev"
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/005
+++ b/tests/nvme/005
@@ -32,7 +32,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"

--- a/tests/nvme/005
+++ b/tests/nvme/005
@@ -34,6 +34,7 @@ test() {
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"${def_subsys_uuid}"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -46,8 +47,9 @@ test() {
 	_nvme_disconnect_ctrl "${nvmedev}"
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
-
 	_remove_nvmet_subsystem "${def_subsysnqn}"
+	_remove_nvmet_host "${def_hostnqn}"
+
 	losetup -d "$loop_dev"
 	rm "${def_file_path}"
 

--- a/tests/nvme/005
+++ b/tests/nvme/005
@@ -31,23 +31,23 @@ test() {
 
 	loop_dev="$(losetup -f --show "$TMPDIR/img")"
 
-	_create_nvmet_subsystem "blktests-subsystem-1" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
-	_add_nvmet_subsys_to_port "${port}" "blktests-subsystem-1"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" blktests-subsystem-1
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "blktests-subsystem-1")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 
 	udevadm settle
 
 	echo 1 > "/sys/class/nvme/${nvmedev}/reset_controller"
 
 	_nvme_disconnect_ctrl "${nvmedev}"
-	_remove_nvmet_subsystem_from_port "${port}" "blktests-subsystem-1"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	_remove_nvmet_subsystem "blktests-subsystem-1"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	losetup -d "$loop_dev"
 	rm "$TMPDIR/img"
 

--- a/tests/nvme/006
+++ b/tests/nvme/006
@@ -28,7 +28,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/006
+++ b/tests/nvme/006
@@ -23,9 +23,9 @@ test() {
 	local port
 	local loop_dev
 
-	truncate -s "${nvme_img_size}" "$TMPDIR/img"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "$TMPDIR/img")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -38,7 +38,7 @@ test() {
 
 	losetup -d "$loop_dev"
 
-	rm "$TMPDIR/img"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/006
+++ b/tests/nvme/006
@@ -22,19 +22,18 @@ test() {
 
 	local port
 	local loop_dev
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "$TMPDIR/img"
 
 	loop_dev="$(losetup -f --show "$TMPDIR/img")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "$loop_dev"

--- a/tests/nvme/006
+++ b/tests/nvme/006
@@ -18,11 +18,11 @@ requires() {
 test() {
 	echo "Running ${TEST_NAME}"
 
+	_setup_nvmet
+
 	local port
 	local loop_dev
 	local subsys_name="blktests-subsystem-1"
-
-	_setup_nvmet
 
 	truncate -s "${nvme_img_size}" "$TMPDIR/img"
 

--- a/tests/nvme/006
+++ b/tests/nvme/006
@@ -21,24 +21,10 @@ test() {
 	_setup_nvmet
 
 	local port
-	local loop_dev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-
-	losetup -d "$loop_dev"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/007
+++ b/tests/nvme/007
@@ -17,11 +17,11 @@ requires() {
 test() {
 	echo "Running ${TEST_NAME}"
 
+	_setup_nvmet
+
 	local port
 	local file_path
 	local subsys_name="blktests-subsystem-1"
-
-	_setup_nvmet
 
 	file_path="${TMPDIR}/img"
 

--- a/tests/nvme/007
+++ b/tests/nvme/007
@@ -24,7 +24,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/007
+++ b/tests/nvme/007
@@ -21,18 +21,9 @@ test() {
 
 	local port
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/007
+++ b/tests/nvme/007
@@ -21,19 +21,18 @@ test() {
 
 	local port
 	local file_path
-	local subsys_name="blktests-subsystem-1"
 
 	file_path="${TMPDIR}/img"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm "${file_path}"

--- a/tests/nvme/007
+++ b/tests/nvme/007
@@ -20,13 +20,10 @@ test() {
 	_setup_nvmet
 
 	local port
-	local file_path
 
-	file_path="${TMPDIR}/img"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -35,7 +32,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/008
+++ b/tests/nvme/008
@@ -29,7 +29,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/008
+++ b/tests/nvme/008
@@ -22,17 +22,8 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,14 +35,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/008
+++ b/tests/nvme/008
@@ -23,11 +23,10 @@ test() {
 	local port
 	local nvmedev
 	local loop_dev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -50,7 +49,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/008
+++ b/tests/nvme/008
@@ -24,29 +24,28 @@ test() {
 	local nvmedev
 	local loop_dev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	udevadm settle
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/008
+++ b/tests/nvme/008
@@ -32,6 +32,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -46,6 +47,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/009
+++ b/tests/nvme/009
@@ -22,27 +22,26 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	udevadm settle
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm "${file_path}"

--- a/tests/nvme/009
+++ b/tests/nvme/009
@@ -25,7 +25,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/009
+++ b/tests/nvme/009
@@ -22,13 +22,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -40,12 +34,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/009
+++ b/tests/nvme/009
@@ -21,11 +21,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -44,7 +43,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/009
+++ b/tests/nvme/009
@@ -28,6 +28,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -42,6 +43,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${def_file_path}"
 

--- a/tests/nvme/010
+++ b/tests/nvme/010
@@ -29,7 +29,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/010
+++ b/tests/nvme/010
@@ -32,6 +32,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -47,6 +48,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/010
+++ b/tests/nvme/010
@@ -23,11 +23,10 @@ test() {
 	local port
 	local nvmedev
 	local loop_dev
-	local file_path="${TMPDIR}/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -51,7 +50,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/010
+++ b/tests/nvme/010
@@ -24,30 +24,29 @@ test() {
 	local nvmedev
 	local loop_dev
 	local file_path="${TMPDIR}/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	_run_fio_verify_io --size="${nvme_img_size}" \
 		--filename="/dev/${nvmedev}n1"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/010
+++ b/tests/nvme/010
@@ -22,17 +22,8 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -45,14 +36,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/011
+++ b/tests/nvme/011
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/011
+++ b/tests/nvme/011
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -42,12 +36,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/011
+++ b/tests/nvme/011
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,6 +45,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${def_file_path}"
 

--- a/tests/nvme/011
+++ b/tests/nvme/011
@@ -22,12 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path
-	local file_path="${TMPDIR}/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -47,7 +45,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/011
+++ b/tests/nvme/011
@@ -24,28 +24,27 @@ test() {
 	local nvmedev
 	local file_path
 	local file_path="${TMPDIR}/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	_run_fio_verify_io --size="${nvme_img_size}" \
 		--filename="/dev/${nvmedev}n1"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm "${file_path}"

--- a/tests/nvme/012
+++ b/tests/nvme/012
@@ -33,7 +33,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/012
+++ b/tests/nvme/012
@@ -28,29 +28,28 @@ test() {
 	local nvmedev
 	local loop_dev
 	local file_path="${TMPDIR}/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	_xfs_run_fio_verify_io "/dev/${nvmedev}n1"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/012
+++ b/tests/nvme/012
@@ -27,11 +27,10 @@ test() {
 	local port
 	local nvmedev
 	local loop_dev
-	local file_path="${TMPDIR}/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -54,7 +53,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/012
+++ b/tests/nvme/012
@@ -36,6 +36,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -50,6 +51,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/012
+++ b/tests/nvme/012
@@ -26,17 +26,8 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -48,14 +39,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/013
+++ b/tests/nvme/013
@@ -25,11 +25,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="${TMPDIR}/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -48,7 +47,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/013
+++ b/tests/nvme/013
@@ -29,7 +29,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/013
+++ b/tests/nvme/013
@@ -26,13 +26,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,12 +38,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/013
+++ b/tests/nvme/013
@@ -26,7 +26,6 @@ test() {
 	local port
 	local nvmedev
 	local file_path="${TMPDIR}/img"
-
 	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"

--- a/tests/nvme/013
+++ b/tests/nvme/013
@@ -32,6 +32,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -46,6 +47,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${def_file_path}"
 

--- a/tests/nvme/013
+++ b/tests/nvme/013
@@ -26,27 +26,26 @@ test() {
 	local port
 	local nvmedev
 	local file_path="${TMPDIR}/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	_xfs_run_fio_verify_io "/dev/${nvmedev}n1"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm "${file_path}"

--- a/tests/nvme/014
+++ b/tests/nvme/014
@@ -22,20 +22,11 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 	local size
 	local bs
 	local count
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		 "${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -54,14 +45,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/014
+++ b/tests/nvme/014
@@ -27,20 +27,19 @@ test() {
 	local bs
 	local count
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -53,10 +52,10 @@ test() {
 
 	nvme flush "/dev/${nvmedev}" -n 1
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/014
+++ b/tests/nvme/014
@@ -35,6 +35,7 @@ test() {
 		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -56,6 +57,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/014
+++ b/tests/nvme/014
@@ -32,7 +32,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/014
+++ b/tests/nvme/014
@@ -26,11 +26,10 @@ test() {
 	local size
 	local bs
 	local count
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -60,7 +59,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/015
+++ b/tests/nvme/015
@@ -29,7 +29,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/015
+++ b/tests/nvme/015
@@ -32,6 +32,7 @@ test() {
 		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -53,6 +54,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${def_file_path}"
 

--- a/tests/nvme/015
+++ b/tests/nvme/015
@@ -26,13 +26,7 @@ test() {
 	local bs
 	local count
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		 "${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -51,12 +45,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/015
+++ b/tests/nvme/015
@@ -26,18 +26,17 @@ test() {
 	local bs
 	local count
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -50,10 +49,10 @@ test() {
 
 	nvme flush "/dev/${nvmedev}n1" -n 1
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm "${file_path}"

--- a/tests/nvme/015
+++ b/tests/nvme/015
@@ -25,11 +25,10 @@ test() {
 	local size
 	local bs
 	local count
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -55,7 +54,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/016
+++ b/tests/nvme/016
@@ -16,12 +16,12 @@ requires() {
 test() {
 	echo "Running ${TEST_NAME}"
 
+	_setup_nvmet
+
 	local port
 	local iterations="${nvme_num_iter}"
 	local loop_dev
 	local subsys_nqn="blktests-subsystem-1"
-
-	_setup_nvmet
 
 	loop_dev="$(losetup -f)"
 	local genctr=1

--- a/tests/nvme/016
+++ b/tests/nvme/016
@@ -21,30 +21,29 @@ test() {
 	local port
 	local iterations="${nvme_num_iter}"
 	local loop_dev
-	local subsys_nqn="blktests-subsystem-1"
 
 	loop_dev="$(losetup -f)"
 	local genctr=1
 
-	_create_nvmet_subsystem "${subsys_nqn}" "${loop_dev}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}"
 
 	for ((i = 2; i <= iterations; i++)); do
-		_create_nvmet_ns "${subsys_nqn}" "${i}" "${loop_dev}"
+		_create_nvmet_ns "${def_subsysnqn}" "${i}" "${loop_dev}"
 	done
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "$port" "${subsys_nqn}"
+	_add_nvmet_subsys_to_port "$port" "${def_subsysnqn}"
 
 	genctr=$(_check_genctr "${genctr}" "adding a subsystem to a port")
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_nqn}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	for ((i = iterations; i > 1; i--)); do
-		_remove_nvmet_ns "${subsys_nqn}" "$i"
+		_remove_nvmet_ns "${def_subsysnqn}" "$i"
 	done
 
-	_remove_nvmet_subsystem "${subsys_nqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/017
+++ b/tests/nvme/017
@@ -16,12 +16,12 @@ requires() {
 test() {
 	echo "Running ${TEST_NAME}"
 
+	_setup_nvmet
+
 	local port
 	local file_path
 	local iterations="${nvme_num_iter}"
 	local subsys_name="blktests-subsystem-1"
-
-	_setup_nvmet
 
 	file_path="${TMPDIR}/img"
 

--- a/tests/nvme/017
+++ b/tests/nvme/017
@@ -21,7 +21,6 @@ test() {
 	local port
 	local file_path
 	local iterations="${nvme_num_iter}"
-	local subsys_name="blktests-subsystem-1"
 
 	file_path="${TMPDIR}/img"
 
@@ -29,26 +28,26 @@ test() {
 
 	local genctr=1
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 
 	for ((i = 2; i <= iterations; i++)); do
-		_create_nvmet_ns "${subsys_name}" "${i}" "${file_path}"
+		_create_nvmet_ns "${def_subsysnqn}" "${i}" "${file_path}"
 	done
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
 	genctr=$(_check_genctr "${genctr}" "adding a subsystem to a port")
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	for ((i = iterations; i > 1; i--)); do
-		_remove_nvmet_ns "${subsys_name}" "$i"
+		_remove_nvmet_ns "${def_subsysnqn}" "$i"
 	done
 
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 
 	rm "${file_path}"
 

--- a/tests/nvme/017
+++ b/tests/nvme/017
@@ -19,20 +19,17 @@ test() {
 	_setup_nvmet
 
 	local port
-	local file_path
 	local iterations="${nvme_num_iter}"
 
-	file_path="${TMPDIR}/img"
-
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	local genctr=1
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 
 	for ((i = 2; i <= iterations; i++)); do
-		_create_nvmet_ns "${def_subsysnqn}" "${i}" "${file_path}"
+		_create_nvmet_ns "${def_subsysnqn}" "${i}" "${def_file_path}"
 	done
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
@@ -49,7 +46,7 @@ test() {
 
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/017
+++ b/tests/nvme/017
@@ -26,7 +26,7 @@ test() {
 	local genctr=1
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 
 	for ((i = 2; i <= iterations; i++)); do
 		_create_nvmet_ns "${def_subsysnqn}" "${i}" "${def_file_path}"

--- a/tests/nvme/018
+++ b/tests/nvme/018
@@ -27,7 +27,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/018
+++ b/tests/nvme/018
@@ -24,18 +24,17 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -47,10 +46,10 @@ test() {
 	nvme read "/dev/${nvmedev}n1" -s "$sectors" -c 0 -z "$bs" &>"$FULL" \
 		&& echo "ERROR: nvme read for out of range LBA was not rejected"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm "${file_path}"

--- a/tests/nvme/018
+++ b/tests/nvme/018
@@ -23,11 +23,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -52,7 +51,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/018
+++ b/tests/nvme/018
@@ -30,6 +30,7 @@ test() {
 		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -50,6 +51,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${def_file_path}"
 

--- a/tests/nvme/018
+++ b/tests/nvme/018
@@ -24,13 +24,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		 "${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -48,12 +42,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/019
+++ b/tests/nvme/019
@@ -34,6 +34,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -48,6 +49,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/019
+++ b/tests/nvme/019
@@ -31,7 +31,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/019
+++ b/tests/nvme/019
@@ -24,7 +24,6 @@ test() {
 	local nvmedev
 	local loop_dev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 	local nblk_range="10,10,10,10,10,10,10,10,10,10"
 	local sblk_range="100,200,300,400,500,600,700,800,900,1000"
 
@@ -32,23 +31,23 @@ test() {
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	nvme dsm "/dev/${nvmedev}" -n 1 -d -s "${sblk_range}" -b "${nblk_range}"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/019
+++ b/tests/nvme/019
@@ -22,19 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 	local nblk_range="10,10,10,10,10,10,10,10,10,10"
 	local sblk_range="100,200,300,400,500,600,700,800,900,1000"
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -46,14 +37,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/019
+++ b/tests/nvme/019
@@ -23,13 +23,12 @@ test() {
 	local port
 	local nvmedev
 	local loop_dev
-	local file_path="$TMPDIR/img"
 	local nblk_range="10,10,10,10,10,10,10,10,10,10"
 	local sblk_range="100,200,300,400,500,600,700,800,900,1000"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -52,7 +51,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/020
+++ b/tests/nvme/020
@@ -30,6 +30,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,6 +45,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/020
+++ b/tests/nvme/020
@@ -24,13 +24,7 @@ test() {
 	local nblk_range="10,10,10,10,10,10,10,10,10,10"
 	local sblk_range="100,200,300,400,500,600,700,800,900,1000"
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -42,12 +36,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/020
+++ b/tests/nvme/020
@@ -22,29 +22,28 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 	local nblk_range="10,10,10,10,10,10,10,10,10,10"
 	local sblk_range="100,200,300,400,500,600,700,800,900,1000"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	nvme dsm "/dev/${nvmedev}" -n 1 -d -s "${sblk_range}" -b "${nblk_range}"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/020
+++ b/tests/nvme/020
@@ -27,7 +27,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/020
+++ b/tests/nvme/020
@@ -21,13 +21,12 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 	local nblk_range="10,10,10,10,10,10,10,10,10,10"
 	local sblk_range="100,200,300,400,500,600,700,800,900,1000"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -46,7 +45,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/021
+++ b/tests/nvme/021
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/021
+++ b/tests/nvme/021
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -43,12 +37,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/021
+++ b/tests/nvme/021
@@ -22,11 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -47,7 +46,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/021
+++ b/tests/nvme/021
@@ -23,18 +23,17 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -42,10 +41,10 @@ test() {
 		echo "ERROR: device not listed"
 	fi
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/021
+++ b/tests/nvme/021
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -45,6 +46,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/022
+++ b/tests/nvme/022
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/022
+++ b/tests/nvme/022
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -43,12 +37,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/022
+++ b/tests/nvme/022
@@ -22,11 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -47,7 +46,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/022
+++ b/tests/nvme/022
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -45,6 +46,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/022
+++ b/tests/nvme/022
@@ -23,18 +23,17 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -42,10 +41,10 @@ test() {
 		echo "ERROR: reset failed"
 	fi
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -29,7 +29,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -23,11 +23,10 @@ test() {
 	local port
 	local nvmedev
 	local loop_dev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -52,7 +51,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -22,17 +22,8 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -46,14 +37,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -24,20 +24,19 @@ test() {
 	local nvmedev
 	local loop_dev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -45,10 +44,10 @@ test() {
 		echo "ERROR: smart-log bdev-ns failed"
 	fi
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -32,6 +32,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -48,6 +49,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/024
+++ b/tests/nvme/024
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/024
+++ b/tests/nvme/024
@@ -22,11 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -46,7 +45,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/024
+++ b/tests/nvme/024
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,6 +45,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/024
+++ b/tests/nvme/024
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -42,12 +36,7 @@ test() {
 	fi
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/024
+++ b/tests/nvme/024
@@ -23,28 +23,27 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	if ! nvme smart-log "/dev/${nvmedev}" -n 1 >> "$FULL" 2>&1; then
 		echo "ERROR: smart-log file-ns failed"
 	fi
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/025
+++ b/tests/nvme/025
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/025
+++ b/tests/nvme/025
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -43,12 +37,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/025
+++ b/tests/nvme/025
@@ -22,11 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -47,7 +46,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/025
+++ b/tests/nvme/025
@@ -23,18 +23,17 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -42,10 +41,10 @@ test() {
 		echo "ERROR: effects-log failed"
 	fi
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/025
+++ b/tests/nvme/025
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -45,6 +46,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -23,18 +23,17 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -42,10 +41,10 @@ test() {
 		echo "ERROR: ns-desc failed"
 	fi
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -43,12 +37,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -22,11 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -47,7 +46,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -45,6 +46,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/027
+++ b/tests/nvme/027
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/027
+++ b/tests/nvme/027
@@ -22,11 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -46,7 +45,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/027
+++ b/tests/nvme/027
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,6 +45,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/027
+++ b/tests/nvme/027
@@ -23,28 +23,27 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	if ! nvme ns-rescan "/dev/${nvmedev}" >> "$FULL" 2>&1; then
 		echo "ERROR: ns-rescan failed"
 	fi
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/027
+++ b/tests/nvme/027
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -40,14 +34,10 @@ test() {
 	if ! nvme ns-rescan "/dev/${nvmedev}" >> "$FULL" 2>&1; then
 		echo "ERROR: ns-rescan failed"
 	fi
+
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/028
+++ b/tests/nvme/028
@@ -26,7 +26,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/028
+++ b/tests/nvme/028
@@ -22,11 +22,10 @@ test() {
 
 	local port
 	local nvmedev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -46,7 +45,7 @@ test() {
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/028
+++ b/tests/nvme/028
@@ -29,6 +29,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -44,6 +45,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm -f "${def_file_path}"
 

--- a/tests/nvme/028
+++ b/tests/nvme/028
@@ -23,13 +23,7 @@ test() {
 	local port
 	local nvmedev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -40,14 +34,10 @@ test() {
 	if ! nvme list-subsys 2>> "$FULL" | grep -q "${nvme_trtype}"; then
 		echo "ERROR: list-subsys"
 	fi
+
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/028
+++ b/tests/nvme/028
@@ -23,28 +23,27 @@ test() {
 	local port
 	local nvmedev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
 	if ! nvme list-subsys 2>> "$FULL" | grep -q "${nvme_trtype}"; then
 		echo "ERROR: list-subsys"
 	fi
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	rm -f "${file_path}"

--- a/tests/nvme/029
+++ b/tests/nvme/029
@@ -62,7 +62,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/029
+++ b/tests/nvme/029
@@ -55,17 +55,8 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		 "${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -83,14 +74,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/029
+++ b/tests/nvme/029
@@ -56,11 +56,10 @@ test() {
 	local port
 	local nvmedev
 	local loop_dev
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -89,7 +88,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/029
+++ b/tests/nvme/029
@@ -65,6 +65,7 @@ test() {
 		 "${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
@@ -85,6 +86,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/029
+++ b/tests/nvme/029
@@ -57,20 +57,19 @@ test() {
 	local nvmedev
 	local loop_dev
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		 "91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 	cat "/sys/block/${nvmedev}n1/uuid"
 	cat "/sys/block/${nvmedev}n1/wwid"
 
@@ -82,10 +81,10 @@ test() {
 	test_user_io "$dev" 511 1023 > "$FULL" 2>&1 || echo FAIL
 	test_user_io "$dev" 511 1025 > "$FULL" 2>&1 || echo FAIL
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/030
+++ b/tests/nvme/030
@@ -28,6 +28,7 @@ test() {
 
 	_create_nvmet_subsystem "${subsys}1" "$(losetup -f)"
 	_add_nvmet_subsys_to_port "${port}" "${subsys}1"
+	_create_nvmet_host "${subsys}1" "${def_hostnqn}"
 
 	genctr=$(_discovery_genctr)
 
@@ -36,13 +37,13 @@ test() {
 
 	genctr=$(_check_genctr "${genctr}" "adding a subsystem to a port")
 
-	echo 0 > "${NVMET_CFS}/subsystems/${subsys}2/attr_allow_any_host"
+	_add_nvmet_allow_hosts "${subsys}2" "${def_hostnqn}"
 
-	genctr=$(_check_genctr "${genctr}" "clearing attr_allow_any_host")
+	genctr=$(_check_genctr "${genctr}" "adding host to allow_hosts")
 
-	echo 1 > "${NVMET_CFS}/subsystems/${subsys}2/attr_allow_any_host"
+	_remove_nvmet_allow_hosts "${subsys}2" "${def_hostnqn}"
 
-	genctr=$(_check_genctr "${genctr}" "setting attr_allow_any_host")
+	genctr=$(_check_genctr "${genctr}" "removing host from allow_hosts")
 
 	_remove_nvmet_subsystem_from_port "${port}" "${subsys}2"
 	_remove_nvmet_subsystem "${subsys}2"
@@ -51,8 +52,8 @@ test() {
 
 	_remove_nvmet_subsystem_from_port "${port}" "${subsys}1"
 	_remove_nvmet_subsystem "${subsys}1"
-
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/030
+++ b/tests/nvme/030
@@ -16,13 +16,13 @@ requires() {
 }
 
 test() {
-	local port
-	local genctr
-	local subsys="blktests-subsystem-"
-
 	echo "Running ${TEST_NAME}"
 
 	_setup_nvmet
+
+	local port
+	local genctr
+	local subsys="blktests-subsystem-"
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 

--- a/tests/nvme/031
+++ b/tests/nvme/031
@@ -33,9 +33,9 @@ test() {
 	local loop_dev
 	local port
 
-	truncate -s "${nvme_img_size}" "$TMPDIR/img"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "$TMPDIR/img")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
@@ -50,7 +50,7 @@ test() {
 
 	_remove_nvmet_port "${port}"
 	losetup -d "$loop_dev"
-	rm "$TMPDIR/img"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/031
+++ b/tests/nvme/031
@@ -24,14 +24,14 @@ requires() {
 }
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys="blktests-subsystem-"
 	local iterations=10
 	local loop_dev
 	local port
-
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 
 	truncate -s "${nvme_img_size}" "$TMPDIR/img"
 

--- a/tests/nvme/033
+++ b/tests/nvme/033
@@ -49,7 +49,7 @@ test_device() {
 
 	_setup_nvmet
 
-	local subsys="blktests-subsystem-1"
+	local subsys="${def_subsysnqn}"
 	local nsdev
 	local port
 

--- a/tests/nvme/033
+++ b/tests/nvme/033
@@ -45,13 +45,14 @@ compare_dev_info() {
 }
 
 test_device() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys="blktests-subsystem-1"
 	local nsdev
 	local port
 
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 	port=$(_nvmet_passthru_target_setup "${subsys}")
 
 	nsdev=$(_nvmet_passthru_target_connect "${nvme_trtype}" "${subsys}")

--- a/tests/nvme/034
+++ b/tests/nvme/034
@@ -19,7 +19,7 @@ test_device() {
 
 	_setup_nvmet
 
-	local subsys="blktests-subsystem-1"
+	local subsys="${def_subsysnqn}"
 	local ctrldev
 	local nsdev
 	local port

--- a/tests/nvme/034
+++ b/tests/nvme/034
@@ -15,14 +15,15 @@ requires() {
 }
 
 test_device() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys="blktests-subsystem-1"
 	local ctrldev
 	local nsdev
 	local port
 
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 	port=$(_nvmet_passthru_target_setup "${subsys}")
 	nsdev=$(_nvmet_passthru_target_connect "${nvme_trtype}" "${subsys}")
 

--- a/tests/nvme/035
+++ b/tests/nvme/035
@@ -25,7 +25,7 @@ test_device() {
 
 	_setup_nvmet
 
-	local subsys="blktests-subsystem-1"
+	local subsys="${def_subsysnqn}"
 	local ctrldev
 	local nsdev
 	local port

--- a/tests/nvme/035
+++ b/tests/nvme/035
@@ -21,14 +21,15 @@ device_requires() {
 }
 
 test_device() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys="blktests-subsystem-1"
 	local ctrldev
 	local nsdev
 	local port
 
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 	port=$(_nvmet_passthru_target_setup "${subsys}")
 	nsdev=$(_nvmet_passthru_target_connect "${nvme_trtype}" "${subsys}")
 

--- a/tests/nvme/036
+++ b/tests/nvme/036
@@ -14,13 +14,14 @@ requires() {
 }
 
 test_device() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys="blktests-subsystem-1"
 	local ctrldev
 	local port
 
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 	port=$(_nvmet_passthru_target_setup "${subsys}")
 	nsdev=$(_nvmet_passthru_target_connect "${nvme_trtype}" "${subsys}")
 

--- a/tests/nvme/036
+++ b/tests/nvme/036
@@ -18,7 +18,7 @@ test_device() {
 
 	_setup_nvmet
 
-	local subsys="blktests-subsystem-1"
+	local subsys="${def_subsysnqn}"
 	local ctrldev
 	local port
 

--- a/tests/nvme/037
+++ b/tests/nvme/037
@@ -13,14 +13,14 @@ requires() {
 }
 
 test_device() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys="blktests-subsystem-"
 	local iterations=10
 	local ctrldev
 	local port
-
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 
 	for ((i = 0; i < iterations; i++)); do
 		port=$(_nvmet_passthru_target_setup "${subsys}${i}")

--- a/tests/nvme/038
+++ b/tests/nvme/038
@@ -19,12 +19,12 @@ requires() {
 }
 
 test() {
-	local subsys_path="${NVMET_CFS}/subsystems/blktests-subsystem-1"
-	local port
-
 	echo "Running ${TEST_NAME}"
 
 	_setup_nvmet
+
+	local subsys_path="${NVMET_CFS}/subsystems/blktests-subsystem-1"
+	local port
 
 	mkdir -p "${subsys_path}"
 	rmdir "${subsys_path}"

--- a/tests/nvme/038
+++ b/tests/nvme/038
@@ -23,7 +23,7 @@ test() {
 
 	_setup_nvmet
 
-	local subsys_path="${NVMET_CFS}/subsystems/blktests-subsystem-1"
+	local subsys_path="${NVMET_CFS}/subsystems/${def_subsysnqn}"
 	local port
 
 	mkdir -p "${subsys_path}"

--- a/tests/nvme/039
+++ b/tests/nvme/039
@@ -131,11 +131,11 @@ inject_invalid_admin_cmd()
 }
 
 test_device() {
+	echo "Running ${TEST_NAME}"
+
 	local nvme_verbose_errors
 	local ns_dev
 	local ctrl_dev
-
-	echo "Running ${TEST_NAME}"
 
 	if _check_kernel_option NVME_VERBOSE_ERRORS; then
 		nvme_verbose_errors=true

--- a/tests/nvme/040
+++ b/tests/nvme/040
@@ -21,7 +21,6 @@ test() {
 
 	_setup_nvmet
 
-	local subsys="blktests-subsystem-1"
 	local file_path="${TMPDIR}/img"
 	local port
 	local loop_dev
@@ -32,11 +31,11 @@ test() {
 	loop_dev="$(losetup -f --show "${file_path}")"
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_create_nvmet_subsystem "${subsys}" "${loop_dev}"
-	_add_nvmet_subsys_to_port "${port}" "${subsys}"
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 	udevadm settle
-	nvmedev=$(_find_nvme_dev "${subsys}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 
 	# start fio job
 	echo "starting background fio"
@@ -55,8 +54,8 @@ test() {
 
 	{ kill "${fio_pid}"; wait; } &> /dev/null
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys}"
-	_remove_nvmet_subsystem "${subsys}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/040
+++ b/tests/nvme/040
@@ -32,6 +32,8 @@ test() {
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 	udevadm settle
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
@@ -56,6 +58,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/040
+++ b/tests/nvme/040
@@ -17,6 +17,10 @@ requires() {
 }
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys="blktests-subsystem-1"
 	local file_path="${TMPDIR}/img"
 	local port
@@ -24,9 +28,6 @@ test() {
 	local nvmedev
 	local fio_pid
 
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 	truncate -s "${nvme_img_size}" "${file_path}"
 	loop_dev="$(losetup -f --show "${file_path}")"
 

--- a/tests/nvme/040
+++ b/tests/nvme/040
@@ -21,14 +21,13 @@ test() {
 
 	_setup_nvmet
 
-	local file_path="${TMPDIR}/img"
 	local port
 	local loop_dev
 	local nvmedev
 	local fio_pid
 
-	truncate -s "${nvme_img_size}" "${file_path}"
-	loop_dev="$(losetup -f --show "${file_path}")"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}"
@@ -60,7 +59,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm -f "${file_path}"
+	rm -f "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/040
+++ b/tests/nvme/040
@@ -22,17 +22,10 @@ test() {
 	_setup_nvmet
 
 	local port
-	local loop_dev
 	local nvmedev
 	local fio_pid
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 	udevadm settle
@@ -55,14 +48,7 @@ test() {
 
 	{ kill "${fio_pid}"; wait; } &> /dev/null
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm -f "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -25,7 +25,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local subsys_name="blktests-subsystem-1"
 	local hostid
 	local hostnqn
 	local file_path="${TMPDIR}/img"
@@ -34,7 +33,7 @@ test() {
 
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
-	hostkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "nvme gen-dhchap-key failed"
 		return 1
@@ -42,33 +41,33 @@ test() {
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"b92842df-a394-44b1-84a4-92ae7d112861"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
-	_create_nvmet_host "${subsys_name}" "${hostnqn}" "${hostkey}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" "${hostkey}"
 
 	# Test unauthenticated connection (should fail)
 	echo "Test unauthenticated connection (should fail)"
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 			     --hostnqn "${hostnqn}" \
 			     --hostid "${hostid}"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	# Test authenticated connection
 	echo "Test authenticated connection"
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 			     --hostnqn "${hostnqn}" \
 			     --hostid "${hostid}" \
 			     --dhchap-secret "${hostkey}"
 
 	udevadm settle
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 
 	_remove_nvmet_port "${port}"
 

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -34,13 +34,7 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}"
+	port="$(_nvmet_target_setup --blkdev=file --hostkey "${hostkey}")"
 
 	# Test unauthenticated connection (should fail)
 	echo "Test unauthenticated connection (should fail)"
@@ -61,14 +55,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-
-	_remove_nvmet_port "${port}"
-
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -25,14 +25,10 @@ test() {
 	_setup_nvmet
 
 	local port
-	local hostid
-	local hostnqn
 	local file_path="${TMPDIR}/img"
 	local hostkey
 	local ctrldev
 
-	hostid="${def_hostid}"
-	hostnqn="${def_hostnqn}"
 	hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "nvme gen-dhchap-key failed"
@@ -45,21 +41,21 @@ test() {
 		"b92842df-a394-44b1-84a4-92ae7d112861"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" "${hostkey}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}"
 
 	# Test unauthenticated connection (should fail)
 	echo "Test unauthenticated connection (should fail)"
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-			     --hostnqn "${hostnqn}" \
-			     --hostid "${hostid}"
+			     --hostnqn "${def_hostnqn}" \
+			     --hostid "${def_hostid}"
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	# Test authenticated connection
 	echo "Test authenticated connection"
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-			     --hostnqn "${hostnqn}" \
-			     --hostid "${hostid}" \
+			     --hostnqn "${def_hostnqn}" \
+			     --hostid "${def_hostid}" \
 			     --dhchap-secret "${hostkey}"
 
 	udevadm settle
@@ -71,7 +67,7 @@ test() {
 
 	_remove_nvmet_port "${port}"
 
-	_remove_nvmet_host "${hostnqn}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${file_path}"
 

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -37,7 +37,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"b92842df-a394-44b1-84a4-92ae7d112861"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}"

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -25,7 +25,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local file_path="${TMPDIR}/img"
 	local hostkey
 	local ctrldev
 
@@ -35,9 +34,9 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"b92842df-a394-44b1-84a4-92ae7d112861"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
@@ -69,7 +68,7 @@ test() {
 
 	_remove_nvmet_host "${def_hostnqn}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -20,6 +20,10 @@ requires() {
 
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local port
 	local subsys_name="blktests-subsystem-1"
 	local hostid
@@ -28,8 +32,6 @@ test() {
 	local hostkey
 	local ctrldev
 
-	echo "Running ${TEST_NAME}"
-
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
 	hostkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
@@ -37,8 +39,6 @@ test() {
 		echo "nvme gen-dhchap-key failed"
 		return 1
 	fi
-
-	_setup_nvmet
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -25,15 +25,14 @@ test() {
 	_setup_nvmet
 
 	local port
-	local file_path="${TMPDIR}/img"
 	local hmac
 	local key_len
 	local hostkey
 	local ctrldev
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
@@ -82,7 +81,7 @@ test() {
 
 	_remove_nvmet_host "${def_hostnqn}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -20,6 +20,10 @@ requires() {
 
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local port
 	local subsys_name="blktests-subsystem-1"
 	local hostid
@@ -30,12 +34,8 @@ test() {
 	local hostkey
 	local ctrldev
 
-	echo "Running ${TEST_NAME}"
-
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
-
-	_setup_nvmet
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -25,23 +25,18 @@ test() {
 	_setup_nvmet
 
 	local port
-	local hostid
-	local hostnqn
 	local file_path="${TMPDIR}/img"
 	local hmac
 	local key_len
 	local hostkey
 	local ctrldev
 
-	hostid="${def_hostid}"
-	hostnqn="${def_hostnqn}"
-
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	for hmac in 0 1 2 3; do
 		echo "Testing hmac ${hmac}"
@@ -50,11 +45,11 @@ test() {
 			echo "couldn't generate host key for hmac ${hmac}"
 			return 1
 		fi
-		_set_nvmet_hostkey "${hostnqn}" "${hostkey}"
+		_set_nvmet_hostkey "${def_hostnqn}" "${hostkey}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-				     --hostnqn "${hostnqn}" \
-				     --hostid "${hostid}" \
+				     --hostnqn "${def_hostnqn}" \
+				     --hostid "${def_hostid}" \
 				     --dhchap-secret "${hostkey}"
 		udevadm settle
 
@@ -68,11 +63,11 @@ test() {
 			echo "couldn't generate host key for length ${key_len}"
 			return 1
 		fi
-		_set_nvmet_hostkey "${hostnqn}" "${hostkey}"
+		_set_nvmet_hostkey "${def_hostnqn}" "${hostkey}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-				     --hostnqn "${hostnqn}" \
-				     --hostid "${hostid}" \
+				     --hostnqn "${def_hostnqn}" \
+				     --hostid "${def_hostid}" \
 				     --dhchap-secret "${hostkey}"
 
 		udevadm settle
@@ -85,7 +80,7 @@ test() {
 
 	_remove_nvmet_port "${port}"
 
-	_remove_nvmet_host "${hostnqn}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${file_path}"
 

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -25,7 +25,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local subsys_name="blktests-subsystem-1"
 	local hostid
 	local hostnqn
 	local file_path="${TMPDIR}/img"
@@ -39,50 +38,50 @@ test() {
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
-	_create_nvmet_host "${subsys_name}" "${hostnqn}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}"
 
 	for hmac in 0 1 2 3; do
 		echo "Testing hmac ${hmac}"
-		hostkey="$(nvme gen-dhchap-key --hmac=${hmac} -n ${subsys_name} 2> /dev/null)"
+		hostkey="$(nvme gen-dhchap-key --hmac=${hmac} -n ${def_subsysnqn} 2> /dev/null)"
 		if [ -z "$hostkey" ] ; then
 			echo "couldn't generate host key for hmac ${hmac}"
 			return 1
 		fi
 		_set_nvmet_hostkey "${hostnqn}" "${hostkey}"
 
-		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 				     --hostnqn "${hostnqn}" \
 				     --hostid "${hostid}" \
 				     --dhchap-secret "${hostkey}"
 		udevadm settle
 
-		_nvme_disconnect_subsys "${subsys_name}"
+		_nvme_disconnect_subsys "${def_subsysnqn}"
 	done
 
 	for key_len in 32 48 64; do
 		echo "Testing key length ${key_len}"
-		hostkey="$(nvme gen-dhchap-key --key-length=${key_len} -n ${subsys_name} 2> /dev/null)"
+		hostkey="$(nvme gen-dhchap-key --key-length=${key_len} -n ${def_subsysnqn} 2> /dev/null)"
 		if [ -z "$hostkey" ] ; then
 			echo "couldn't generate host key for length ${key_len}"
 			return 1
 		fi
 		_set_nvmet_hostkey "${hostnqn}" "${hostkey}"
 
-		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 				     --hostnqn "${hostnqn}" \
 				     --hostid "${hostid}" \
 				     --dhchap-secret "${hostkey}"
 
 		udevadm settle
 
-		_nvme_disconnect_subsys "${subsys_name}"
+		_nvme_disconnect_subsys "${def_subsysnqn}"
 	done
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 
 	_remove_nvmet_port "${port}"
 

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -30,12 +30,7 @@ test() {
 	local hostkey
 	local ctrldev
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	for hmac in 0 1 2 3; do
 		echo "Testing hmac ${hmac}"
@@ -74,14 +69,7 @@ test() {
 		_nvme_disconnect_subsys "${def_subsysnqn}"
 	done
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-
-	_remove_nvmet_port "${port}"
-
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -45,10 +45,10 @@ test() {
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
-	_create_nvmet_host "${subsys_name}" "${hostnqn}" "${hostkey}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" "${hostkey}"
 
 	for hash in "hmac(sha256)" "hmac(sha384)" "hmac(sha512)" ; do
 
@@ -56,14 +56,14 @@ test() {
 
 		_set_nvmet_hash "${hostnqn}" "${hash}"
 
-		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 				     --hostnqn "${hostnqn}" \
 				     --hostid "${hostid}" \
 				     --dhchap-secret "${hostkey}"
 
 		udevadm settle
 
-		_nvme_disconnect_subsys "${subsys_name}"
+		_nvme_disconnect_subsys "${def_subsysnqn}"
 	done
 
 	for dhgroup in "ffdhe2048" "ffdhe3072" "ffdhe4096" "ffdhe6144" "ffdhe8192" ; do
@@ -72,18 +72,18 @@ test() {
 
 		_set_nvmet_dhgroup "${hostnqn}" "${dhgroup}"
 
-		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 				      --hostnqn "${hostnqn}" \
 				      --hostid "${hostid}" \
 				      --dhchap-secret "${hostkey}"
 
 		udevadm settle
 
-		_nvme_disconnect_subsys "${subsys_name}"
+		_nvme_disconnect_subsys "${def_subsysnqn}"
 	done
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 
 	_remove_nvmet_port "${port}"
 

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -26,7 +26,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local file_path="${TMPDIR}/img"
 	local hash
 	local dhgroup
 	local hostkey
@@ -38,9 +37,9 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}"
@@ -84,7 +83,7 @@ test() {
 
 	_remove_nvmet_host "${def_hostnqn}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -37,12 +37,7 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}"
+	port="$(_nvmet_target_setup --blkdev=file --hostkey "${hostkey}")"
 
 	for hash in "hmac(sha256)" "hmac(sha384)" "hmac(sha512)" ; do
 
@@ -76,14 +71,7 @@ test() {
 		_nvme_disconnect_subsys "${def_subsysnqn}"
 	done
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-
-	_remove_nvmet_port "${port}"
-
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -21,6 +21,10 @@ requires() {
 
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local port
 	local subsys_name="blktests-subsystem-1"
 	local hostid
@@ -31,8 +35,6 @@ test() {
 	local hostkey
 	local ctrldev
 
-	echo "Running ${TEST_NAME}"
-
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
 	hostkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
@@ -40,8 +42,6 @@ test() {
 		echo "nvme gen-dhchap-key failed"
 		return 1
 	fi
-
-	_setup_nvmet
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -37,7 +37,7 @@ test() {
 
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
-	hostkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	hostkey="$(nvme gen-dhchap-key -n ${hostnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "nvme gen-dhchap-key failed"
 		return 1

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -26,18 +26,13 @@ test() {
 	_setup_nvmet
 
 	local port
-	local subsys_name="blktests-subsystem-1"
-	local hostid
-	local hostnqn
 	local file_path="${TMPDIR}/img"
 	local hash
 	local dhgroup
 	local hostkey
 	local ctrldev
 
-	hostid="${def_hostid}"
-	hostnqn="${def_hostnqn}"
-	hostkey="$(nvme gen-dhchap-key -n ${hostnqn} 2> /dev/null)"
+	hostkey="$(nvme gen-dhchap-key -n ${def_hostnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "nvme gen-dhchap-key failed"
 		return 1
@@ -48,17 +43,17 @@ test() {
 	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" "${hostkey}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}"
 
 	for hash in "hmac(sha256)" "hmac(sha384)" "hmac(sha512)" ; do
 
 		echo "Testing hash ${hash}"
 
-		_set_nvmet_hash "${hostnqn}" "${hash}"
+		_set_nvmet_hash "${def_hostnqn}" "${hash}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-				     --hostnqn "${hostnqn}" \
-				     --hostid "${hostid}" \
+				     --hostnqn "${def_hostnqn}" \
+				     --hostid "${def_hostid}" \
 				     --dhchap-secret "${hostkey}"
 
 		udevadm settle
@@ -70,11 +65,11 @@ test() {
 
 		echo "Testing DH group ${dhgroup}"
 
-		_set_nvmet_dhgroup "${hostnqn}" "${dhgroup}"
+		_set_nvmet_dhgroup "${def_hostnqn}" "${dhgroup}"
 
 		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-				      --hostnqn "${hostnqn}" \
-				      --hostid "${hostid}" \
+				      --hostnqn "${def_hostnqn}" \
+				      --hostid "${def_hostid}" \
 				      --dhchap-secret "${hostkey}"
 
 		udevadm settle
@@ -87,7 +82,7 @@ test() {
 
 	_remove_nvmet_port "${port}"
 
-	_remove_nvmet_host "${hostnqn}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${file_path}"
 

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -26,15 +26,10 @@ test() {
 	_setup_nvmet
 
 	local port
-	local hostid
-	local hostnqn
 	local file_path="${TMPDIR}/img"
 	local hostkey
 	local ctrlkey
 	local ctrldev
-
-	hostid="${def_hostid}"
-	hostnqn="${def_hostnqn}"
 
 	hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
@@ -53,16 +48,16 @@ test() {
 	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" \
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" \
 			   "${hostkey}" "${ctrlkey}"
 
-	_set_nvmet_dhgroup "${hostnqn}" "ffdhe2048"
+	_set_nvmet_dhgroup "${def_hostnqn}" "ffdhe2048"
 
 	# Step 1: Connect with host authentication only
 	echo "Test host authentication"
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-			     --hostnqn "${hostnqn}" \
-			     --hostid "${hostid}" \
+			     --hostnqn "${def_hostnqn}" \
+			     --hostid "${def_hostid}" \
 			     --dhchap-secret "${hostkey}"
 
 	udevadm settle
@@ -73,8 +68,8 @@ test() {
 	# and invalid ctrl authentication
 	echo "Test invalid ctrl authentication (should fail)"
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-			     --hostnqn "${hostnqn}" \
-			     --hostid "${hostid}" \
+			     --hostnqn "${def_hostnqn}" \
+			     --hostid "${def_hostid}" \
 			     --dhchap-secret "${hostkey}" \
 			     --dhchap-ctrl-secret "${hostkey}"
 
@@ -86,8 +81,8 @@ test() {
 	# and valid ctrl authentication
 	echo "Test valid ctrl authentication"
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-			     --hostnqn "${hostnqn}" \
-			     --hostid "${hostid}" \
+			     --hostnqn "${def_hostnqn}" \
+			     --hostid "${def_hostid}" \
 			     --dhchap-secret "${hostkey}" \
 			     --dhchap-ctrl-secret "${ctrlkey}"
 
@@ -100,8 +95,8 @@ test() {
 	echo "Test invalid ctrl key (should fail)"
 	invkey="DHHC-1:00:Jc/My1o0qtLCWRp+sHhAVafdfaS7YQOMYhk9zSmlatobqB8C:"
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-			     --hostnqn "${hostnqn}" \
-			     --hostid "${hostid}" \
+			     --hostnqn "${def_hostnqn}" \
+			     --hostid "${def_hostid}" \
 			     --dhchap-secret "${hostkey}" \
 			     --dhchap-ctrl-secret "${invkey}"
 
@@ -114,7 +109,7 @@ test() {
 
 	_remove_nvmet_port "${port}"
 
-	_remove_nvmet_host "${hostnqn}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${file_path}"
 

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -21,6 +21,10 @@ requires() {
 
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local port
 	local subsys_name="blktests-subsystem-1"
 	local hostid
@@ -29,8 +33,6 @@ test() {
 	local hostkey
 	local ctrlkey
 	local ctrldev
-
-	echo "Running ${TEST_NAME}"
 
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
@@ -46,8 +48,6 @@ test() {
 		echo "failed to generate ctrl key"
 		return 1
 	fi
-
-	_setup_nvmet
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -42,13 +42,8 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" \
-			   "${hostkey}" "${ctrlkey}"
+	port="$(_nvmet_target_setup --blkdev=file --ctrlkey "${ctrlkey}" \
+			 --hostkey "${hostkey}")"
 
 	_set_nvmet_dhgroup "${def_hostnqn}" "ffdhe2048"
 
@@ -103,14 +98,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-
-	_remove_nvmet_port "${port}"
-
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -26,7 +26,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local subsys_name="blktests-subsystem-1"
 	local hostid
 	local hostnqn
 	local file_path="${TMPDIR}/img"
@@ -37,13 +36,13 @@ test() {
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
 
-	hostkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "failed to generate host key"
 		return 1
 	fi
 
-	ctrlkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	ctrlkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$ctrlkey" ] ; then
 		echo "failed to generate ctrl key"
 		return 1
@@ -51,29 +50,29 @@ test() {
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
-	_create_nvmet_host "${subsys_name}" "${hostnqn}" \
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" \
 			   "${hostkey}" "${ctrlkey}"
 
 	_set_nvmet_dhgroup "${hostnqn}" "ffdhe2048"
 
 	# Step 1: Connect with host authentication only
 	echo "Test host authentication"
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 			     --hostnqn "${hostnqn}" \
 			     --hostid "${hostid}" \
 			     --dhchap-secret "${hostkey}"
 
 	udevadm settle
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	# Step 2: Connect with host authentication
 	# and invalid ctrl authentication
 	echo "Test invalid ctrl authentication (should fail)"
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 			     --hostnqn "${hostnqn}" \
 			     --hostid "${hostid}" \
 			     --dhchap-secret "${hostkey}" \
@@ -81,12 +80,12 @@ test() {
 
 	udevadm settle
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	# Step 3: Connect with host authentication
 	# and valid ctrl authentication
 	echo "Test valid ctrl authentication"
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 			     --hostnqn "${hostnqn}" \
 			     --hostid "${hostid}" \
 			     --dhchap-secret "${hostkey}" \
@@ -94,13 +93,13 @@ test() {
 
 	udevadm settle
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	# Step 4: Connect with host authentication
 	# and invalid ctrl key
 	echo "Test invalid ctrl key (should fail)"
 	invkey="DHHC-1:00:Jc/My1o0qtLCWRp+sHhAVafdfaS7YQOMYhk9zSmlatobqB8C:"
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 			     --hostnqn "${hostnqn}" \
 			     --hostid "${hostid}" \
 			     --dhchap-secret "${hostkey}" \
@@ -108,10 +107,10 @@ test() {
 
 	udevadm settle
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 
 	_remove_nvmet_port "${port}"
 

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -26,7 +26,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local file_path="${TMPDIR}/img"
 	local hostkey
 	local ctrlkey
 	local ctrldev
@@ -43,9 +42,9 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" \
@@ -111,7 +110,7 @@ test() {
 
 	_remove_nvmet_host "${def_hostnqn}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -46,12 +46,8 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}" "${ctrlkey}"
+	port="$(_nvmet_target_setup --blkdev=file --ctrlkey "${ctrlkey}" \
+			--hostkey "${hostkey}")"
 
 	_set_nvmet_dhgroup "${def_hostnqn}" "ffdhe2048"
 
@@ -116,14 +112,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-
-	_remove_nvmet_port "${port}"
-
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -22,6 +22,10 @@ requires() {
 
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local port
 	local subsys_name="blktests-subsystem-1"
 	local hostid
@@ -33,8 +37,6 @@ test() {
 	local new_ctrlkey
 	local ctrldev
 	local rand_io_size
-
-	echo "Running ${TEST_NAME}"
 
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
@@ -50,8 +52,6 @@ test() {
 		echo "failed to generate ctrl key"
 		return 1
 	fi
-
-	_setup_nvmet
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -27,7 +27,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local file_path="${TMPDIR}/img"
 	local hostkey
 	local new_hostkey
 	local ctrlkey
@@ -47,9 +46,9 @@ test() {
 		return 1
 	fi
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}" "${ctrlkey}"
@@ -124,7 +123,7 @@ test() {
 
 	_remove_nvmet_host "${def_hostnqn}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -27,7 +27,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local subsys_name="blktests-subsystem-1"
 	local hostid
 	local hostnqn
 	local file_path="${TMPDIR}/img"
@@ -41,13 +40,13 @@ test() {
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"
 
-	hostkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "failed to generate host key"
 		return 1
 	fi
 
-	ctrlkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	ctrlkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$ctrlkey" ] ; then
 		echo "failed to generate ctrl key"
 		return 1
@@ -55,14 +54,14 @@ test() {
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}"
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
-	_create_nvmet_host "${subsys_name}" "${hostnqn}" "${hostkey}" "${ctrlkey}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" "${hostkey}" "${ctrlkey}"
 
 	_set_nvmet_dhgroup "${hostnqn}" "ffdhe2048"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 			     --hostnqn "${hostnqn}" \
 			     --hostid "${hostid}" \
 			     --dhchap-secret "${hostkey}" \
@@ -72,7 +71,7 @@ test() {
 
 	echo "Re-authenticate with original host key"
 
-	ctrldev=$(_find_nvme_dev "${subsys_name}")
+	ctrldev=$(_find_nvme_dev "${def_subsysnqn}")
 	if [ -z "$ctrldev" ] ; then
 		echo "nvme controller not found"
 	fi
@@ -81,7 +80,7 @@ test() {
 
 	echo "Renew host key on the controller"
 
-	new_hostkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	new_hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 
 	_set_nvmet_hostkey "${hostnqn}" "${new_hostkey}"
 
@@ -91,7 +90,7 @@ test() {
 
 	echo "Renew ctrl key on the controller"
 
-	new_ctrlkey="$(nvme gen-dhchap-key -n ${subsys_name} 2> /dev/null)"
+	new_ctrlkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 
 	_set_nvmet_ctrlkey "${hostnqn}" "${new_ctrlkey}"
 
@@ -116,15 +115,15 @@ test() {
 
 	echo "${new_hostkey}" > "${hostkey_file}"
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 
 	rand_io_size="$(_nvme_calc_rand_io_size 4m)"
 	_run_fio_rand_io --size="${rand_io_size}" --filename="/dev/${nvmedev}n1"
 
-	_nvme_disconnect_subsys "${subsys_name}"
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 
 	_remove_nvmet_port "${port}"
 

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -27,8 +27,6 @@ test() {
 	_setup_nvmet
 
 	local port
-	local hostid
-	local hostnqn
 	local file_path="${TMPDIR}/img"
 	local hostkey
 	local new_hostkey
@@ -36,9 +34,6 @@ test() {
 	local new_ctrlkey
 	local ctrldev
 	local rand_io_size
-
-	hostid="${def_hostid}"
-	hostnqn="${def_hostnqn}"
 
 	hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
@@ -57,13 +52,13 @@ test() {
 	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${hostnqn}" "${hostkey}" "${ctrlkey}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" "${hostkey}" "${ctrlkey}"
 
-	_set_nvmet_dhgroup "${hostnqn}" "ffdhe2048"
+	_set_nvmet_dhgroup "${def_hostnqn}" "ffdhe2048"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-			     --hostnqn "${hostnqn}" \
-			     --hostid "${hostid}" \
+			     --hostnqn "${def_hostnqn}" \
+			     --hostid "${def_hostid}" \
 			     --dhchap-secret "${hostkey}" \
 			     --dhchap-ctrl-secret "${ctrlkey}"
 
@@ -82,7 +77,7 @@ test() {
 
 	new_hostkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 
-	_set_nvmet_hostkey "${hostnqn}" "${new_hostkey}"
+	_set_nvmet_hostkey "${def_hostnqn}" "${new_hostkey}"
 
 	echo "Re-authenticate with new host key"
 
@@ -92,7 +87,7 @@ test() {
 
 	new_ctrlkey="$(nvme gen-dhchap-key -n ${def_subsysnqn} 2> /dev/null)"
 
-	_set_nvmet_ctrlkey "${hostnqn}" "${new_ctrlkey}"
+	_set_nvmet_ctrlkey "${def_hostnqn}" "${new_ctrlkey}"
 
 	echo "Re-authenticate with new ctrl key"
 
@@ -101,7 +96,7 @@ test() {
 
 	echo "Change DH group to ffdhe8192"
 
-	_set_nvmet_dhgroup "${hostnqn}" "ffdhe8192"
+	_set_nvmet_dhgroup "${def_hostnqn}" "ffdhe8192"
 
 	echo "Re-authenticate with changed DH group"
 
@@ -109,7 +104,7 @@ test() {
 
 	echo "Change hash to hmac(sha512)"
 
-	_set_nvmet_hash "${hostnqn}" "hmac(sha512)"
+	_set_nvmet_hash "${def_hostnqn}" "hmac(sha512)"
 
 	echo "Re-authenticate with changed hash"
 
@@ -127,7 +122,7 @@ test() {
 
 	_remove_nvmet_port "${port}"
 
-	_remove_nvmet_host "${hostnqn}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${file_path}"
 

--- a/tests/nvme/046
+++ b/tests/nvme/046
@@ -16,6 +16,7 @@ requires() {
 
 test_device() {
 	echo "Running ${TEST_NAME}"
+
 	local ngdev=${TEST_DEV/nvme/ng}
 	local perm nsid
 

--- a/tests/nvme/047
+++ b/tests/nvme/047
@@ -35,6 +35,7 @@ test() {
 		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 		--nr-write-queues 1 || echo FAIL
@@ -57,6 +58,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	losetup -d "${loop_dev}"
 

--- a/tests/nvme/047
+++ b/tests/nvme/047
@@ -32,7 +32,7 @@ test() {
 	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 

--- a/tests/nvme/047
+++ b/tests/nvme/047
@@ -24,18 +24,9 @@ test() {
 
 	local port
 	local nvmedev
-	local loop_dev
 	local rand_io_size
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	loop_dev="$(losetup -f --show "${def_file_path}")"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=device)"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 		--nr-write-queues 1 || echo FAIL
@@ -55,14 +46,7 @@ test() {
 
 	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	losetup -d "${loop_dev}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/047
+++ b/tests/nvme/047
@@ -27,37 +27,36 @@ test() {
 	local loop_dev
 	local rand_io_size
 	local file_path="$TMPDIR/img"
-	local subsys_name="blktests-subsystem-1"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	loop_dev="$(losetup -f --show "${file_path}")"
 
-	_create_nvmet_subsystem "${subsys_name}" "${loop_dev}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 		--nr-write-queues 1 || echo FAIL
 
-	nvmedev=$(_find_nvme_dev "${subsys_name}")
+	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
 
 	rand_io_size="$(_nvme_calc_rand_io_size 4M)"
 	_run_fio_rand_io --filename="/dev/${nvmedev}n1" --size="${rand_io_size}"
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 		--nr-write-queues 1 \
 		--nr-poll-queues 1 || echo FAIL
 
 	_run_fio_rand_io --filename="/dev/${nvmedev}n1" --size="${rand_io_size}"
 
-	_nvme_disconnect_subsys "${subsys_name}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 
 	losetup -d "${loop_dev}"

--- a/tests/nvme/047
+++ b/tests/nvme/047
@@ -26,11 +26,10 @@ test() {
 	local nvmedev
 	local loop_dev
 	local rand_io_size
-	local file_path="$TMPDIR/img"
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	loop_dev="$(losetup -f --show "${file_path}")"
+	loop_dev="$(losetup -f --show "${def_file_path}")"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${loop_dev}" \
 		"91fdba0d-f87b-4c25-b80f-db7be1418b9e"
@@ -61,7 +60,7 @@ test() {
 
 	losetup -d "${loop_dev}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	echo "Test complete"
 }

--- a/tests/nvme/048
+++ b/tests/nvme/048
@@ -85,8 +85,7 @@ test() {
 
 	_setup_nvmet
 
-	local subsys_name="blktests-subsystem-1"
-	local cfs_path="${NVMET_CFS}/subsystems/${subsys_name}"
+	local cfs_path="${NVMET_CFS}/subsystems/${def_subsysnqn}"
 	local file_path="${TMPDIR}/img"
 	local skipped=false
 	local hostnqn
@@ -98,34 +97,34 @@ test() {
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
-	_create_nvmet_subsystem "${subsys_name}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"b92842df-a394-44b1-84a4-92ae7d112861"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
-	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
-	_create_nvmet_host "${subsys_name}" "${hostnqn}"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	if [[ -f "${cfs_path}/attr_qid_max" ]] ; then
-		_nvme_connect_subsys "${nvme_trtype}" "${subsys_name}" \
+		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 					--hostnqn "${hostnqn}" \
 					--hostid "${hostid}" \
 					--keep-alive-tmo 1 \
 					--reconnect-delay 2
 
-		if ! nvmf_wait_for_state "${subsys_name}" "live" ; then
+		if ! nvmf_wait_for_state "${def_subsysnqn}" "live" ; then
 			echo FAIL
 		else
-			set_qid_max "${port}" "${subsys_name}" 1 || echo FAIL
-			set_qid_max "${port}" "${subsys_name}" 2 || echo FAIL
+			set_qid_max "${port}" "${def_subsysnqn}" 1 || echo FAIL
+			set_qid_max "${port}" "${def_subsysnqn}" 2 || echo FAIL
 		fi
 
-		_nvme_disconnect_subsys "${subsys_name}"
+		_nvme_disconnect_subsys "${def_subsysnqn}"
 	else
 		SKIP_REASONS+=("missing attr_qid_max feature")
 		skipped=true
 	fi
 
-	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
-	_remove_nvmet_subsystem "${subsys_name}"
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
 	_remove_nvmet_host "${hostnqn}"
 

--- a/tests/nvme/048
+++ b/tests/nvme/048
@@ -88,25 +88,21 @@ test() {
 	local cfs_path="${NVMET_CFS}/subsystems/${def_subsysnqn}"
 	local file_path="${TMPDIR}/img"
 	local skipped=false
-	local hostnqn
-	local hostid
 	local port
-
-	hostid="${def_hostid}"
-	hostnqn="${def_hostnqn}"
 
 	truncate -s "${nvme_img_size}" "${file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
 		"b92842df-a394-44b1-84a4-92ae7d112861"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
+
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
 	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
 
 	if [[ -f "${cfs_path}/attr_qid_max" ]] ; then
 		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
-					--hostnqn "${hostnqn}" \
-					--hostid "${hostid}" \
+					--hostnqn "${def_hostnqn}" \
+					--hostid "${def_hostid}" \
 					--keep-alive-tmo 1 \
 					--reconnect-delay 2
 
@@ -126,7 +122,7 @@ test() {
 	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
 	_remove_nvmet_subsystem "${def_subsysnqn}"
 	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${hostnqn}"
+	_remove_nvmet_host "${def_hostnqn}"
 
 	rm "${file_path}"
 

--- a/tests/nvme/048
+++ b/tests/nvme/048
@@ -86,13 +86,12 @@ test() {
 	_setup_nvmet
 
 	local cfs_path="${NVMET_CFS}/subsystems/${def_subsysnqn}"
-	local file_path="${TMPDIR}/img"
 	local skipped=false
 	local port
 
-	truncate -s "${nvme_img_size}" "${file_path}"
+	truncate -s "${nvme_img_size}" "${def_file_path}"
 
-	_create_nvmet_subsystem "${def_subsysnqn}" "${file_path}" \
+	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
 		"b92842df-a394-44b1-84a4-92ae7d112861"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
@@ -124,7 +123,7 @@ test() {
 	_remove_nvmet_port "${port}"
 	_remove_nvmet_host "${def_hostnqn}"
 
-	rm "${file_path}"
+	rm "${def_file_path}"
 
 	if [[ "${skipped}" = true ]] ; then
 		return 1

--- a/tests/nvme/048
+++ b/tests/nvme/048
@@ -89,14 +89,7 @@ test() {
 	local skipped=false
 	local port
 
-	truncate -s "${nvme_img_size}" "${def_file_path}"
-
-	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"${def_subsys_uuid}"
-	port="$(_create_nvmet_port "${nvme_trtype}")"
-
-	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
-	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}"
+	port="$(_nvmet_target_setup --blkdev=file)"
 
 	if [[ -f "${cfs_path}/attr_qid_max" ]] ; then
 		_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
@@ -118,12 +111,7 @@ test() {
 		skipped=true
 	fi
 
-	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
-	_remove_nvmet_subsystem "${def_subsysnqn}"
-	_remove_nvmet_port "${port}"
-	_remove_nvmet_host "${def_hostnqn}"
-
-	rm "${def_file_path}"
+	_nvmet_target_cleanup "${port}"
 
 	if [[ "${skipped}" = true ]] ; then
 		return 1

--- a/tests/nvme/048
+++ b/tests/nvme/048
@@ -81,6 +81,10 @@ set_qid_max() {
 }
 
 test() {
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
 	local subsys_name="blktests-subsystem-1"
 	local cfs_path="${NVMET_CFS}/subsystems/${subsys_name}"
 	local file_path="${TMPDIR}/img"
@@ -88,10 +92,6 @@ test() {
 	local hostnqn
 	local hostid
 	local port
-
-	echo "Running ${TEST_NAME}"
-
-	_setup_nvmet
 
 	hostid="${def_hostid}"
 	hostnqn="${def_hostnqn}"

--- a/tests/nvme/048
+++ b/tests/nvme/048
@@ -92,7 +92,7 @@ test() {
 	truncate -s "${nvme_img_size}" "${def_file_path}"
 
 	_create_nvmet_subsystem "${def_subsysnqn}" "${def_file_path}" \
-		"b92842df-a394-44b1-84a4-92ae7d112861"
+		"${def_subsys_uuid}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 
 	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"

--- a/tests/nvme/049
+++ b/tests/nvme/049
@@ -17,6 +17,7 @@ requires() {
 
 test_device() {
 	echo "Running ${TEST_NAME}"
+
 	local ngdev=${TEST_DEV/nvme/ng}
 	local common_args=(
 		--size=1M

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -17,6 +17,7 @@ def_local_wwpn="0x20001100aa000002"
 def_hostid="0f01fb42-9f7f-4856-b0b3-51e60b8de349"
 def_hostnqn="nqn.2014-08.org.nvmexpress:uuid:${def_hostid}"
 def_subsysnqn="blktests-subsystem-1"
+def_file_path="${TMPDIR}/img"
 nvme_trtype=${nvme_trtype:-"loop"}
 nvme_img_size=${nvme_img_size:-"1G"}
 nvme_num_iter=${nvme_num_iter:-"1000"}

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -612,17 +612,32 @@ _create_nvmet_subsystem() {
 	_create_nvmet_ns "${nvmet_subsystem}" "1" "${blkdev}" "${uuid}"
 }
 
+_add_nvmet_allow_hosts() {
+	local nvmet_subsystem="$1"
+	local nvmet_hostnqn="$2"
+	local cfs_path="${NVMET_CFS}/subsystems/${nvmet_subsystem}"
+	local host_path="${NVMET_CFS}/hosts/${nvmet_hostnqn}"
+
+	ln -s "${host_path}" "${cfs_path}/allowed_hosts/${nvmet_hostnqn}"
+}
+
+_remove_nvmet_allow_hosts() {
+	local nvmet_subsystem="$1"
+	local nvmet_hostnqn="$2"
+	local cfs_path="${NVMET_CFS}/subsystems/${nvmet_subsystem}"
+
+	rm "${cfs_path}/allowed_hosts/${nvmet_hostnqn}"
+}
+
 _create_nvmet_host() {
 	local nvmet_subsystem="$1"
 	local nvmet_hostnqn="$2"
 	local nvmet_hostkey="$3"
 	local nvmet_ctrlkey="$4"
-	local cfs_path="${NVMET_CFS}/subsystems/${nvmet_subsystem}"
 	local host_path="${NVMET_CFS}/hosts/${nvmet_hostnqn}"
 
 	mkdir "${host_path}"
-	echo 0 > "${cfs_path}/attr_allow_any_host"
-	ln -s "${host_path}" "${cfs_path}/allowed_hosts/${nvmet_hostnqn}"
+	_add_nvmet_allow_hosts "${nvmet_subsystem}" "${nvmet_hostnqn}"
 	if [[ "${nvmet_hostkey}" ]] ; then
 		echo "${nvmet_hostkey}" > "${host_path}/dhchap_key"
 	fi

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -17,6 +17,7 @@ def_local_wwpn="0x20001100aa000002"
 def_hostid="0f01fb42-9f7f-4856-b0b3-51e60b8de349"
 def_hostnqn="nqn.2014-08.org.nvmexpress:uuid:${def_hostid}"
 def_subsysnqn="blktests-subsystem-1"
+def_subsys_uuid="91fdba0d-f87b-4c25-b80f-db7be1418b9e"
 def_file_path="${TMPDIR}/img"
 nvme_trtype=${nvme_trtype:-"loop"}
 nvme_img_size=${nvme_img_size:-"1G"}

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -16,6 +16,7 @@ def_local_wwnn="0x10001100aa000002"
 def_local_wwpn="0x20001100aa000002"
 def_hostid="0f01fb42-9f7f-4856-b0b3-51e60b8de349"
 def_hostnqn="nqn.2014-08.org.nvmexpress:uuid:${def_hostid}"
+def_subsysnqn="blktests-subsystem-1"
 nvme_trtype=${nvme_trtype:-"loop"}
 nvme_img_size=${nvme_img_size:-"1G"}
 nvme_num_iter=${nvme_num_iter:-"1000"}

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -359,6 +359,12 @@ _cleanup_nvmet() {
 	if [[ "${nvme_trtype}" == "rdma" ]]; then
 		stop_soft_rdma
 	fi
+
+	blkdev="$(losetup -l | awk '$6 == "'"${def_file_path}"'" { print $1 }')"
+	for dev in ${blkdev}; do
+		losetup -d "${dev}"
+	done
+	rm -f "${def_file_path}"
 }
 
 _setup_nvmet() {
@@ -777,6 +783,66 @@ _find_nvme_passthru_loop_dev() {
 	dev=$(_find_nvme_dev "${subsys}")
 	nsid=$(_test_dev_nvme_nsid)
 	echo "/dev/${dev}n${nsid}"
+}
+
+_nvmet_target_setup() {
+	local blkdev_type="device"
+	local blkdev
+	local ctrlkey=""
+	local hostkey=""
+	local port
+
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			--blkdev)
+				blkdev_type="$2"
+				shift 2
+				;;
+			--ctrlkey)
+				ctrlkey="$2"
+				shift 2
+				;;
+			--hostkey)
+				hostkey="$2"
+				shift 2
+				;;
+			*)
+				shift
+				;;
+		esac
+	done
+
+	truncate -s "${nvme_img_size}" "${def_file_path}"
+	if [[ "${blkdev_type}" == "device" ]]; then
+		blkdev="$(losetup -f --show "${def_file_path}")"
+	else
+		blkdev="${def_file_path}"
+	fi
+
+	_create_nvmet_subsystem "${def_subsysnqn}" "${blkdev}" \
+				"${def_subsys_uuid}"
+	port="$(_create_nvmet_port "${nvme_trtype}")"
+	_add_nvmet_subsys_to_port "${port}" "${def_subsysnqn}"
+	_create_nvmet_host "${def_subsysnqn}" "${def_hostnqn}" \
+			"${hostkey}" "${ctrlkey}"
+
+	echo "${port}"
+}
+
+_nvmet_target_cleanup() {
+	local port=$1
+	local blkdev
+
+	_remove_nvmet_subsystem_from_port "${port}" "${def_subsysnqn}"
+	_remove_nvmet_subsystem "${def_subsysnqn}"
+	_remove_nvmet_port "${port}"
+	_remove_nvmet_host "${def_hostnqn}"
+
+	blkdev="$(losetup -l | awk '$6 == "'"${def_file_path}"'" { print $1 }')"
+	if [[ -n "${blkdev}" ]] ; then
+		losetup -d "${blkdev}"
+	fi
+	rm "${def_file_path}"
 }
 
 _nvmet_passthru_target_setup() {

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -608,7 +608,7 @@ _create_nvmet_subsystem() {
 	local cfs_path="${NVMET_CFS}/subsystems/${nvmet_subsystem}"
 
 	mkdir -p "${cfs_path}"
-	echo 1 > "${cfs_path}/attr_allow_any_host"
+	echo 0 > "${cfs_path}/attr_allow_any_host"
 	_create_nvmet_ns "${nvmet_subsystem}" "1" "${blkdev}" "${uuid}"
 }
 
@@ -678,7 +678,7 @@ _create_nvmet_passthru() {
 	local passthru_path="${subsys_path}/passthru"
 
 	mkdir -p "${subsys_path}"
-	echo 1 > "${subsys_path}/attr_allow_any_host"
+	echo 0 > "${subsys_path}/attr_allow_any_host"
 
 	_test_dev_nvme_ctrl > "${passthru_path}/device_path"
 	echo 1 > "${passthru_path}/enable"
@@ -693,6 +693,7 @@ _remove_nvmet_passhtru() {
 	local passthru_path="${subsys_path}/passthru"
 
 	echo 0 > "${passthru_path}/enable"
+	rm -f "${subsys_path}"/allowed_hosts/*
 	rmdir "${subsys_path}"
 }
 
@@ -784,6 +785,7 @@ _nvmet_passthru_target_setup() {
 	_create_nvmet_passthru "${subsys_name}"
 	port="$(_create_nvmet_port "${nvme_trtype}")"
 	_add_nvmet_subsys_to_port "${port}" "${subsys_name}"
+	_create_nvmet_host "${subsys_name}" "${def_hostnqn}"
 
 	echo "$port"
 }
@@ -810,6 +812,7 @@ _nvmet_passthru_target_cleanup() {
 	_remove_nvmet_subsystem_from_port "${port}" "${subsys_name}"
 	_remove_nvmet_port "${port}"
 	_remove_nvmet_passhtru "${subsys_name}"
+	_remove_nvmet_host "${def_hostnqn}"
 }
 
 _discovery_genctr() {


### PR DESCRIPTION
When the host has enabled the udev/systemd autoconnect services for the fc transport it interacts with blktests and make tests break.

nvme-cli learned to ignore connects attemps when using the --context command line option paired with a volatile configuration. Thus we can mark all the resources created by blktests and avoid any interaction with the systemd autoconnect scripts.