### PR TITLE
Allow for pre-defined UUID and subsystem NQN

### DIFF
--- a/tests/nvme/003.out
+++ b/tests/nvme/003.out
@@ -1,3 +1,2 @@
 Running nvme/003
-NQN:nqn.2014-08.org.nvmexpress.discovery disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/004
+++ b/tests/nvme/004
@@ -29,8 +29,7 @@ test() {
 
 	local nvmedev
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	_nvme_disconnect_subsys ${def_subsysnqn}
 

--- a/tests/nvme/004.out
+++ b/tests/nvme/004.out
@@ -1,5 +1,3 @@
 Running nvme/004
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/004.out
+++ b/tests/nvme/004.out
@@ -1,3 +1,2 @@
 Running nvme/004
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/008
+++ b/tests/nvme/008
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 

--- a/tests/nvme/008.out
+++ b/tests/nvme/008.out
@@ -1,5 +1,3 @@
 Running nvme/008
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/008.out
+++ b/tests/nvme/008.out
@@ -1,3 +1,2 @@
 Running nvme/008
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/009
+++ b/tests/nvme/009
@@ -26,8 +26,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	_nvme_disconnect_subsys "${def_subsysnqn}"
 

--- a/tests/nvme/009.out
+++ b/tests/nvme/009.out
@@ -1,5 +1,3 @@
 Running nvme/009
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/009.out
+++ b/tests/nvme/009.out
@@ -1,3 +1,2 @@
 Running nvme/009
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/010
+++ b/tests/nvme/010
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	_run_fio_verify_io --size="${nvme_img_size}" \
 		--filename="/dev/${nvmedev}n1"

--- a/tests/nvme/010.out
+++ b/tests/nvme/010.out
@@ -1,5 +1,3 @@
 Running nvme/010
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/010.out
+++ b/tests/nvme/010.out
@@ -1,3 +1,2 @@
 Running nvme/010
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/011
+++ b/tests/nvme/011
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	_run_fio_verify_io --size="${nvme_img_size}" \
 		--filename="/dev/${nvmedev}n1"

--- a/tests/nvme/011.out
+++ b/tests/nvme/011.out
@@ -1,5 +1,3 @@
 Running nvme/011
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/011.out
+++ b/tests/nvme/011.out
@@ -1,3 +1,2 @@
 Running nvme/011
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/012
+++ b/tests/nvme/012
@@ -31,8 +31,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	_xfs_run_fio_verify_io "/dev/${nvmedev}n1"
 

--- a/tests/nvme/012.out
+++ b/tests/nvme/012.out
@@ -1,5 +1,3 @@
 Running nvme/012
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/012.out
+++ b/tests/nvme/012.out
@@ -1,3 +1,2 @@
 Running nvme/012
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/013
+++ b/tests/nvme/013
@@ -30,8 +30,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	_xfs_run_fio_verify_io "/dev/${nvmedev}n1"
 

--- a/tests/nvme/013.out
+++ b/tests/nvme/013.out
@@ -1,5 +1,3 @@
 Running nvme/013
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/013.out
+++ b/tests/nvme/013.out
@@ -1,3 +1,2 @@
 Running nvme/013
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/014
+++ b/tests/nvme/014
@@ -30,8 +30,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	size="$(blockdev --getsize64 "/dev/${nvmedev}n1")"
 	bs="$(blockdev --getbsz "/dev/${nvmedev}n1")"

--- a/tests/nvme/014.out
+++ b/tests/nvme/014.out
@@ -1,6 +1,4 @@
 Running nvme/014
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NVMe Flush: success
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/014.out
+++ b/tests/nvme/014.out
@@ -1,4 +1,3 @@
 Running nvme/014
 NVMe Flush: success
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/015
+++ b/tests/nvme/015
@@ -30,8 +30,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	size="$(blockdev --getsize64 "/dev/${nvmedev}n1")"
 	bs="$(blockdev --getbsz "/dev/${nvmedev}n1")"

--- a/tests/nvme/015.out
+++ b/tests/nvme/015.out
@@ -1,6 +1,4 @@
 Running nvme/015
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NVMe Flush: success
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/015.out
+++ b/tests/nvme/015.out
@@ -1,4 +1,3 @@
 Running nvme/015
 NVMe Flush: success
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/018
+++ b/tests/nvme/018
@@ -28,8 +28,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	local sectors
 	local bs

--- a/tests/nvme/018.out
+++ b/tests/nvme/018.out
@@ -1,5 +1,3 @@
 Running nvme/018
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/018.out
+++ b/tests/nvme/018.out
@@ -1,3 +1,2 @@
 Running nvme/018
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/019
+++ b/tests/nvme/019
@@ -29,8 +29,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	nvme dsm "/dev/${nvmedev}" -n 1 -d -s "${sblk_range}" -b "${nblk_range}"
 

--- a/tests/nvme/019.out
+++ b/tests/nvme/019.out
@@ -1,6 +1,4 @@
 Running nvme/019
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NVMe DSM: success
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/019.out
+++ b/tests/nvme/019.out
@@ -1,4 +1,3 @@
 Running nvme/019
 NVMe DSM: success
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/020
+++ b/tests/nvme/020
@@ -28,8 +28,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	nvme dsm "/dev/${nvmedev}" -n 1 -d -s "${sblk_range}" -b "${nblk_range}"
 

--- a/tests/nvme/020.out
+++ b/tests/nvme/020.out
@@ -1,6 +1,4 @@
 Running nvme/020
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 NVMe DSM: success
 NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/020.out
+++ b/tests/nvme/020.out
@@ -1,4 +1,3 @@
 Running nvme/020
 NVMe DSM: success
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/021
+++ b/tests/nvme/021
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme list 2>> "$FULL" | grep -q "${nvmedev}n1"; then
 		echo "ERROR: device not listed"

--- a/tests/nvme/021
+++ b/tests/nvme/021
@@ -33,7 +33,7 @@ test() {
 		echo "ERROR: device not listed"
 	fi
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/021.out
+++ b/tests/nvme/021.out
@@ -1,4 +1,2 @@
 Running nvme/021
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/022
+++ b/tests/nvme/022
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme reset "/dev/${nvmedev}" >> "$FULL" 2>&1; then
 		echo "ERROR: reset failed"

--- a/tests/nvme/022
+++ b/tests/nvme/022
@@ -33,7 +33,7 @@ test() {
 		echo "ERROR: reset failed"
 	fi
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/022.out
+++ b/tests/nvme/022.out
@@ -1,4 +1,2 @@
 Running nvme/022
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme smart-log "/dev/${nvmedev}" -n 1 >> "$FULL" 2>&1; then
 		echo "ERROR: smart-log bdev-ns failed"

--- a/tests/nvme/023
+++ b/tests/nvme/023
@@ -33,7 +33,7 @@ test() {
 		echo "ERROR: smart-log bdev-ns failed"
 	fi
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/023.out
+++ b/tests/nvme/023.out
@@ -1,4 +1,2 @@
 Running nvme/023
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/024
+++ b/tests/nvme/024
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme smart-log "/dev/${nvmedev}" -n 1 >> "$FULL" 2>&1; then
 		echo "ERROR: smart-log file-ns failed"

--- a/tests/nvme/024
+++ b/tests/nvme/024
@@ -32,7 +32,7 @@ test() {
 	if ! nvme smart-log "/dev/${nvmedev}" -n 1 >> "$FULL" 2>&1; then
 		echo "ERROR: smart-log file-ns failed"
 	fi
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/024.out
+++ b/tests/nvme/024.out
@@ -1,4 +1,2 @@
 Running nvme/024
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/025
+++ b/tests/nvme/025
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme effects-log "/dev/${nvmedev}" >> "$FULL" 2>&1; then
 		echo "ERROR: effects-log failed"

--- a/tests/nvme/025
+++ b/tests/nvme/025
@@ -33,7 +33,7 @@ test() {
 		echo "ERROR: effects-log failed"
 	fi
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/025.out
+++ b/tests/nvme/025.out
@@ -1,4 +1,2 @@
 Running nvme/025
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme ns-descs "/dev/${nvmedev}" -n 1 >> "$FULL" 2>&1; then
 		echo "ERROR: ns-desc failed"

--- a/tests/nvme/026
+++ b/tests/nvme/026
@@ -33,7 +33,7 @@ test() {
 		echo "ERROR: ns-desc failed"
 	fi
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/026.out
+++ b/tests/nvme/026.out
@@ -1,4 +1,2 @@
 Running nvme/026
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/027
+++ b/tests/nvme/027
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme ns-rescan "/dev/${nvmedev}" >> "$FULL" 2>&1; then
 		echo "ERROR: ns-rescan failed"

--- a/tests/nvme/027
+++ b/tests/nvme/027
@@ -33,7 +33,7 @@ test() {
 		echo "ERROR: ns-rescan failed"
 	fi
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/027.out
+++ b/tests/nvme/027.out
@@ -1,4 +1,2 @@
 Running nvme/027
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/028
+++ b/tests/nvme/028
@@ -27,8 +27,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	if ! nvme list-subsys 2>> "$FULL" | grep -q "${nvme_trtype}"; then
 		echo "ERROR: list-subsys"

--- a/tests/nvme/028
+++ b/tests/nvme/028
@@ -33,7 +33,7 @@ test() {
 		echo "ERROR: list-subsys"
 	fi
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/028.out
+++ b/tests/nvme/028.out
@@ -1,4 +1,2 @@
 Running nvme/028
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/029
+++ b/tests/nvme/029
@@ -60,8 +60,7 @@ test() {
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}"
 
 	nvmedev=$(_find_nvme_dev "${def_subsysnqn}")
-	cat "/sys/block/${nvmedev}n1/uuid"
-	cat "/sys/block/${nvmedev}n1/wwid"
+	_check_uuid "${nvmedev}"
 
 	local dev="/dev/${nvmedev}n1"
 	test_user_io "$dev" 1 512 > "$FULL" 2>&1 || echo FAIL

--- a/tests/nvme/029
+++ b/tests/nvme/029
@@ -70,7 +70,7 @@ test() {
 	test_user_io "$dev" 511 1023 > "$FULL" 2>&1 || echo FAIL
 	test_user_io "$dev" 511 1025 > "$FULL" 2>&1 || echo FAIL
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/029.out
+++ b/tests/nvme/029.out
@@ -1,4 +1,2 @@
 Running nvme/029
-91fdba0d-f87b-4c25-b80f-db7be1418b9e
-uuid.91fdba0d-f87b-4c25-b80f-db7be1418b9e
 Test complete

--- a/tests/nvme/031
+++ b/tests/nvme/031
@@ -44,7 +44,7 @@ test() {
 		_add_nvmet_subsys_to_port "${port}" "${subsys}$i"
 		_create_nvmet_host "${subsys}$i" "${def_hostnqn}"
 		_nvme_connect_subsys "${nvme_trtype}" "${subsys}$i"
-		_nvme_disconnect_subsys "${subsys}$i" >> "${FULL}" 2>&1
+		_nvme_disconnect_subsys "${subsys}$i"
 		_remove_nvmet_subsystem_from_port "${port}" "${subsys}$i"
 		_remove_nvmet_subsystem "${subsys}$i"
 		_remove_nvmet_host "${def_hostnqn}"

--- a/tests/nvme/033.out
+++ b/tests/nvme/033.out
@@ -1,3 +1,2 @@
 Running nvme/033
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/034.out
+++ b/tests/nvme/034.out
@@ -1,3 +1,2 @@
 Running nvme/034
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/035.out
+++ b/tests/nvme/035.out
@@ -1,3 +1,2 @@
 Running nvme/035
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/036.out
+++ b/tests/nvme/036.out
@@ -1,3 +1,2 @@
 Running nvme/036
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/037
+++ b/tests/nvme/037
@@ -26,7 +26,7 @@ test_device() {
 		nsdev=$(_nvmet_passthru_target_connect "${nvme_trtype}" \
 				"${subsys}${i}")
 
-		_nvme_disconnect_subsys "${subsys}${i}" >>"${FULL}" 2>&1
+		_nvme_disconnect_subsys "${subsys}${i}"
 		_nvmet_passthru_target_cleanup "${subsys}${i}"
 	done
 

--- a/tests/nvme/041.out
+++ b/tests/nvme/041.out
@@ -1,6 +1,4 @@
 Running nvme/041
 Test unauthenticated connection (should fail)
-NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test authenticated connection
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/042.out
+++ b/tests/nvme/042.out
@@ -1,16 +1,9 @@
 Running nvme/042
 Testing hmac 0
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing hmac 1
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing hmac 2
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing hmac 3
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing key length 32
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing key length 48
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing key length 64
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/043.out
+++ b/tests/nvme/043.out
@@ -1,18 +1,10 @@
 Running nvme/043
 Testing hash hmac(sha256)
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing hash hmac(sha384)
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing hash hmac(sha512)
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing DH group ffdhe2048
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing DH group ffdhe3072
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing DH group ffdhe4096
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing DH group ffdhe6144
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Testing DH group ffdhe8192
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/044.out
+++ b/tests/nvme/044.out
@@ -1,10 +1,6 @@
 Running nvme/044
 Test host authentication
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test invalid ctrl authentication (should fail)
-NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test valid ctrl authentication
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test invalid ctrl key (should fail)
-NQN:blktests-subsystem-1 disconnected 0 controller(s)
 Test complete

--- a/tests/nvme/045.out
+++ b/tests/nvme/045.out
@@ -8,5 +8,4 @@ Change DH group to ffdhe8192
 Re-authenticate with changed DH group
 Change hash to hmac(sha512)
 Re-authenticate with changed hash
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/047
+++ b/tests/nvme/047
@@ -35,7 +35,7 @@ test() {
 	rand_io_size="$(_nvme_calc_rand_io_size 4M)"
 	_run_fio_rand_io --filename="/dev/${nvmedev}n1" --size="${rand_io_size}"
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvme_connect_subsys "${nvme_trtype}" "${def_subsysnqn}" \
 		--nr-write-queues 1 \
@@ -43,7 +43,7 @@ test() {
 
 	_run_fio_rand_io --filename="/dev/${nvmedev}n1" --size="${rand_io_size}"
 
-	_nvme_disconnect_subsys "${def_subsysnqn}" >> "$FULL" 2>&1
+	_nvme_disconnect_subsys "${def_subsysnqn}"
 
 	_nvmet_target_cleanup
 

--- a/tests/nvme/048.out
+++ b/tests/nvme/048.out
@@ -1,3 +1,2 @@
 Running nvme/048
-NQN:blktests-subsystem-1 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -959,6 +959,27 @@ _check_genctr() {
 	echo "${genctr}"
 }
 
+_check_uuid() {
+	local nvmedev=$1
+	local nr_nsid=0
+
+	for ns in "/sys/block/${nvmedev}n"* ; do
+		[ -e "${ns}/wwid" ] || continue
+		nr_nsid=$((nr_nsid + 1))
+		[ -e "${ns}/uuid" ] || continue
+		uuid=$(cat "${ns}/uuid")
+		wwid=$(cat "${ns}/wwid")
+		if [ "${uuid}" != "${wwid#uuid.}" ]; then
+			echo "UUID ${uuid} mismatch (wwid ${wwid})"
+			return 1
+		fi
+	done
+	if [ $nr_nsid -eq 0 ] ; then
+		echo "No namespaces found"
+		return 1
+	fi
+}
+
 declare -A NS_DEV_FAULT_INJECT_SAVE
 declare -A CTRL_DEV_FAULT_INJECT_SAVE
 

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -430,7 +430,7 @@ _nvme_disconnect_ctrl() {
 _nvme_disconnect_subsys() {
 	local subsysnqn="$1"
 
-	nvme disconnect -n "${subsysnqn}"
+	nvme disconnect -n "${subsysnqn}" >> "$FULL" 2>&1
 }
 
 _nvme_connect_subsys() {


### PR DESCRIPTION
When running against a pre-defined target we might not be able to set the UUID/WWID, and the subsystem NQN will not be the default subsystem NQN. This patchset avoid to register either of those in the 'out' files such that we can attempt to run against external targets.