### PR TITLE
nvme/rc: don't print the nvme connect msg

### DIFF
--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -576,7 +576,7 @@ _nvme_connect_subsys() {
 		ARGS+=(--ctrl-loss-tmo="${ctrl_loss_tmo}")
 	fi
 
-	nvme connect "${ARGS[@]}" 2> /dev/null
+	nvme connect "${ARGS[@]}" 2> /dev/null | grep -v "connecting to device:"
 
 	# Wait until device file and uuid/wwid sysfs attributes get ready for
 	# all namespaces.


### PR DESCRIPTION
With commit [1], the nvme connect command will show the connect msg which breaks blktests nvme/ related cases[2], fix it from blktests side.

[1]
https://github.com/linux-nvme/nvme-cli/commit/0b8d1e03049c5092d705bcd3ce369f02a9472f95 
[2]
$ ./check nvme/003
nvme/003 (test if we're sending keep-alives to a discovery controller) [failed]
    runtime  11.344s  ...  11.346s
    --- tests/nvme/003.out	2024-01-10 04:03:21.975035862 +0100
    +++ /root/blktests/results/nodev/nvme/003.out.bad	2024-01-10 07:19:46.978193215 +0100
    @@ -1,3 +1,4 @@
     Running nvme/003
    +connecting to device: nvme0
     disconnected 1 controller(s)
     Test complete