### PR TITLE
nbd/001: change to use lsblk raw output format

### DIFF
--- a/tests/nbd/001
+++ b/tests/nbd/001
@@ -19,12 +19,12 @@ test() {
 	_start_nbd_server
 	nbd-client -L -N export localhost /dev/nbd0 >> "$FULL" 2>&1
 	parted -s /dev/nbd0 print 2>> "$FULL" | grep 'Disk /dev/nbd0'
-	lsblk -n /dev/nbd0
+	lsblk --raw --noheadings /dev/nbd0
 
 	echo "Setting size to 1gib"
 	src/nbdsetsize /dev/nbd0 1073741824
 
-	lsblk -n /dev/nbd0
+	lsblk --raw --noheadings /dev/nbd0
 	parted -s /dev/nbd0 print 2>> "$FULL" | grep 'Disk /dev/nbd0'
 
 	nbd-client -d /dev/nbd0 >> "$FULL" 2>&1

--- a/tests/nbd/001.out
+++ b/tests/nbd/001.out
@@ -1,6 +1,6 @@
 Running nbd/001
 Disk /dev/nbd0: 10.7GB
-nbd0  43:0    0  10G  0 disk 
+nbd0 43:0 0 10G 0 disk 
 Setting size to 1gib
-nbd0  43:0    0   1G  0 disk 
+nbd0 43:0 0 1G 0 disk 
 Disk /dev/nbd0: 1074MB


### PR DESCRIPTION
lsblk -n ouput format changed due to the substantial changes
in libsmartcols, which lsblk relies on for generating output,
fix it by using the raw format

Fixes: #132