### PR TITLE
nbd/002: wait for the device node to show up

### DIFF
--- a/tests/nbd/002
+++ b/tests/nbd/002
@@ -84,6 +84,7 @@ test() {
 	# Do it with netlink
 	echo "Testing the netlink path"
 	nbd-client -L -N export localhost /dev/nbd0 >> "$FULL" 2>&1
+	udevadm settle
 
 	if ! _wait_for_nbd_connect; then
 		echo "Connect didn't happen?"


### PR DESCRIPTION
Fix the nbd/002 failure recently found by CKI:

nbd/002 (tests on partition handling for an nbd device)
nbd/002 (tests on partition handling for an nbd device)      [failed]
    runtime    ...  3.679s
    --- tests/nbd/002.out	2024-03-07 15:21:19.796849151 -0500
    +++ /mnt/tests/gitlab.com/redhat/centos-stream/tests/kernel/kernel-tests/-/archive/production/kernel-tests-production.zip/storage/blktests/blk/blktests/results/nodev/nbd/002.out.bad	2024-03-07 16:01:23.838920252 -0500
    @@ -1,4 +1,4 @@
     Running nbd/002
     Testing IOCTL path
     Testing the netlink path
    -Test complete
    +Didn't have partition on the netlink path