### PR TITLE
Patch fixing test case issue which use to failed in old kernel , this…

### DIFF
--- a/tests/loop/010
+++ b/tests/loop/010
@@ -11,6 +11,7 @@ DESCRIPTION="check stale loop partition"
 TIMED=1
 
 requires() {
+        _have_kver 6 11 
 	_have_program parted
 	_have_program mkfs.xfs
 }


### PR DESCRIPTION
… patch skip

test case if test runs in older kenrel less than 6.11

log:

[root@linux blktests]#  ./check loop/010
loop/010 (check stale loop partition)                        [not run]
    Kernel version too old