### PR TITLE
nvme/049: update fio_output msg check for io_uring_cmd support

### DIFF
--- a/tests/nvme/049
+++ b/tests/nvme/049
@@ -37,7 +37,8 @@ test_device() {
 	# check security permission
 	if ! fio_output=$(fio --name=check --size=4k --filename="$ngdev" \
 			    --rw=read --ioengine=io_uring_cmd 2>&1) &&
-			grep -qe "Permission denied" <<< "$fio_output"; then
+			grep -q -e "Operation not permitted" \
+				-e "Permission denied" <<< "$fio_output"; then
 		SKIP_REASONS+=("IORING_OP_URING_CMD is not allowed for $ngdev")
 		return
 	fi


### PR DESCRIPTION
Update the error info check string:
check: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=io_uring_cmd, iodepth=1 fio-3.38-16-g6f3de
Starting 1 process
fio: pid=9638, err=1/file:engines/io_uring.c:1272, func=io_queue_init, error=Operation not permitted

Run status group 0 (all jobs):