### PR TITLE
zbd/012: Test requeuing of zoned writes and queue freezing

### DIFF
--- a/tests/zbd/012
+++ b/tests/zbd/012
@@ -1,0 +1,78 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0+
+# Copyright (C) 2024 Google LLC
+#
+# Test concurrent requeuing of zoned writes and request queue freezing. It
+# triggers a hang in the kernel 6.10..6.12 zone write plugging implementation.
+
+. tests/zbd/rc
+. common/scsi_debug
+
+DESCRIPTION="test requeuing of zoned writes and queue freezing"
+TIMED=1
+
+requires() {
+	_have_fio_zbd_zonemode
+}
+
+toggle_iosched() {
+	local iosched
+
+	while true; do
+		for iosched in none mq-deadline; do
+			echo "${iosched}" > "/sys/class/block/$(basename "$zdev")/queue/scheduler"
+			sleep .1
+		done
+	done
+}
+
+test() {
+	echo "Running ${TEST_NAME}"
+
+	# To do: make this test pass for qd > 1.
+	local qd=1
+	echo "$qd"
+	local scsi_debug_params=(
+		delay=0
+		dev_size_mb=1024
+		every_nth=$((2 * qd))
+		max_queue="${qd}"
+		opts=0x8000          # SDEBUG_OPT_HOST_BUSY
+		sector_size=4096
+		zbc=host-managed
+		zone_nr_conv=0
+		zone_size_mb=4
+	)
+	_init_scsi_debug "${scsi_debug_params[@]}" &&
+		local zdev="/dev/${SCSI_DEBUG_DEVICES[0]}" fail &&
+		ls -ld "${zdev}" >>"${FULL}" &&
+		{ toggle_iosched & } &&
+		toggle_iosched_pid=$! &&
+		local fail &&
+		local fio_args=(
+			--direct=1
+			--filename="${zdev}"
+			--iodepth="${qd}"
+			--ioengine=io_uring
+			--ioscheduler=none
+			--name="requeuing-and-queue-freezing-${qd}"
+			--runtime="${TIMEOUT:-30}"
+			--rw=randwrite
+			--time_based
+			--zonemode=zbd
+		)
+	if ! fio "${fio_args[@]}" >>"${FULL}" 2>&1; then
+		fail=true
+	fi
+	if [ -n "${toggle_iosched_pid}" ]; then
+		kill "${toggle_iosched_pid}" >>"${FULL}" 2>&1
+	fi
+	_exit_scsi_debug >>"${FULL}" 2>&1
+
+	if [ -z "$fail" ]; then
+		echo "Test complete"
+	else
+		echo "Test failed"
+		return 1
+	fi
+}

--- a/tests/zbd/012.out
+++ b/tests/zbd/012.out
@@ -1,0 +1,3 @@
+Running zbd/012
+1
+Test complete


### PR DESCRIPTION
Test concurrent requeuing of zoned writes and request queue freezing. While this test passes with kernel 6.9, it triggers a hang with kernels 6.10..6.12. This shows that this hang is a regression introduced by the zone write plugging code.

sysrq: Show Blocked State
task:(udev-worker)   state:D stack:0     pid:75392 tgid:75392 ppid:2178   flags:0x00000006
Call Trace:
 <TASK>
 __schedule+0x3e8/0x1410
 schedule+0x27/0xf0
 blk_mq_freeze_queue_wait+0x6f/0xa0
 queue_attr_store+0x60/0xc0
 kernfs_fop_write_iter+0x13e/0x1f0
 vfs_write+0x25b/0x420
 ksys_write+0x65/0xe0
 do_syscall_64+0x82/0x160
 entry_SYSCALL_64_after_hwframe+0x76/0x7e