### PR TITLE
throtl/{002,003}: update max_sectors setting

### DIFF
--- a/tests/throtl/002
+++ b/tests/throtl/002
@@ -13,7 +13,11 @@ QUICK=1
 test() {
 	echo "Running ${TEST_NAME}"
 
-	if ! _set_up_throtl max_sectors=8; then
+	local page_size max_secs
+	page_size=$(getconf PAGE_SIZE)
+	max_secs=$((page_size / 512))
+
+	if ! _set_up_throtl max_sectors="${max_secs}"; then
 		return 1;
 	fi
 

--- a/tests/throtl/003
+++ b/tests/throtl/003
@@ -13,7 +13,11 @@ QUICK=1
 test() {
 	echo "Running ${TEST_NAME}"
 
-	if ! _set_up_throtl max_sectors=8; then
+	local page_size max_secs
+	page_size=$(getconf PAGE_SIZE)
+	max_secs=$((page_size / 512))
+
+	if ! _set_up_throtl max_sectors="${max_secs}"; then
 		return 1;
 	fi
 


### PR DESCRIPTION
On 64k ppc64le kernel, the max_sectors should be set by (64k/512), or it will trigger below WARNING:

[  299.201428] ------------[ cut here ]------------ [  299.201453] WARNING: CPU: 3 PID: 4680 at block/blk-settings.c:286 blk_validate_limits+0x440/0x540 [  299.201471] Modules linked in: null_blk bonding tls rfkill ibmveth sg pseries_rng vmx_crypto fuse loop nfnetlink xfs sd_mod ibmvscsi scsi_transport_srp dm_mirror dm_region_hash dm_log dm_mod [  299.201508] CPU: 3 UID: 0 PID: 4680 Comm: bash Kdump: loaded Not tainted 6.13.0-0.rc2.22.eln144.ppc64le #1 [  299.201517] Hardware name: IBM,9009-22A POWER9 (architected) 0x4e0202 0xf000005 of:IBM,FW910.00 (VL910_062) hv:phyp pSeries [  299.201523] NIP:  c00000000098ccc0 LR: c000000000987280 CTR: 0000000000000000
[  299.201529] REGS: c0000000502372a0 TRAP: 0700   Not tainted  (6.13.0-0.rc2.22.eln144.ppc64le)
[  299.201536] MSR:  8000000000029033 <SF,EE,ME,IR,DR,RI,LE>  CR: 84228480  XER: 20040000
[  299.201551] CFAR: c00000000098c984 IRQMASK: 0
[  299.201551] GPR00: c000000000987264 c000000050237540 c000000001e0a000 c0000000502377c8
[  299.201551] GPR04: 0000000000000200 00000000f0647558 0000000000001152 0000000000001151
[  299.201551] GPR08: 0000000000000000 0000000000000000 0000000000000200 0000000000008000
[  299.201551] GPR12: c0000000009a2a50 c00000000f8ccb00 0000000000000000 0000000000000000
[  299.201551] GPR16: 0000000000000000 0000000000000000 0000000000000000 0000000000000000
[  299.201551] GPR20: 0000000000000000 0000000000000000 0000000000000000 0000000000000000
[  299.201551] GPR24: c000000002c2acf8 c00000000303de60 0000000000000000 c0000000502377c8
[  299.201551] GPR28: c008000006ec07c8 0000000000000200 0000000000000008 c0000000502377c8
[  299.201618] NIP [c00000000098ccc0] blk_validate_limits+0x440/0x540
[  299.201625] LR [c000000000987280] blk_alloc_queue+0xc0/0x2f0
[  299.201634] Call Trace:
[  299.201637] [c000000050237540] [c0000000587564e0] 0xc0000000587564e0 (unreliable)
[  299.201651] [c0000000502375c0] [c000000000987264] blk_alloc_queue+0xa4/0x2f0
[  299.201659] [c000000050237620] [c0000000009a22e8] blk_mq_alloc_queue+0x88/0x130
[  299.201667] [c000000050237720] [c0000000009a2a80] __blk_mq_alloc_disk+0x30/0xc4
[  299.201674] [c000000050237760] [c008000006e025bc] null_add_dev+0x2a4/0x6d0 [null_blk]
[  299.201687] [c0000000502378c0] [c008000006e03e0c] nullb_device_power_store+0x194/0x200 [null_blk]
[  299.201700] [c000000050237920] [c000000000853128] configfs_write_iter+0x118/0x210
[  299.201712] [c000000050237970] [c000000000731244] vfs_write+0x304/0x500
[  299.201720] [c000000050237a20] [c000000000731638] ksys_write+0x88/0x150
[  299.201728] [c000000050237a70] [c000000000031288] system_call_exception+0x138/0x2d0
[  299.201737] [c000000050237e50] [c00000000000d05c] system_call_vectored_common+0x15c/0x2ec