### PR TITLE
zbd/012: Test higher queue depths

### DIFF
--- a/tests/zbd/012
+++ b/tests/zbd/012
@@ -29,46 +29,53 @@ toggle_iosched() {
 test() {
 	echo "Running ${TEST_NAME}"
 
-	# To do: make this test pass for qd > 1.
-	local qd=1
-	echo "$qd"
-	local scsi_debug_params=(
-		delay=0
-		dev_size_mb=1024
-		every_nth=$((2 * qd))
-		max_queue="${qd}"
-		opts=0x8000          # SDEBUG_OPT_HOST_BUSY
-		sector_size=4096
-		zbc=host-managed
-		zone_nr_conv=0
-		zone_size_mb=4
-	)
-	_init_scsi_debug "${scsi_debug_params[@]}" &&
-		local zdev="/dev/${SCSI_DEBUG_DEVICES[0]}" fail &&
-		ls -ld "${zdev}" >>"${FULL}" &&
-		{ toggle_iosched & } &&
-		toggle_iosched_pid=$! &&
-		local fail &&
-		local fio_args=(
-			--direct=1
-			--filename="${zdev}"
-			--iodepth="${qd}"
-			--ioengine=io_uring
-			--ioscheduler=none
-			--name="requeuing-and-queue-freezing-${qd}"
-			--runtime="${TIMEOUT:-30}"
-			--rw=randwrite
-			--time_based
-			--zonemode=zbd
+	for qd in 1 2 4 8 16; do
+		echo "$qd"
+		local scsi_debug_params=(
+			delay=0
+			dev_size_mb=1024
+			every_nth=$((2 * qd))
+			max_queue="${qd}"
+			opts=0x8000          # SDEBUG_OPT_HOST_BUSY
+			sector_size=4096
+			zbc=host-managed
+			zone_nr_conv=0
+			zone_size_mb=4
 		)
-	if ! fio "${fio_args[@]}" >>"${FULL}" 2>&1; then
-		fail=true
-	fi
-	if [ -n "${toggle_iosched_pid}" ]; then
-		kill "${toggle_iosched_pid}" >>"${FULL}" 2>&1
-	fi
-	_exit_scsi_debug >>"${FULL}" 2>&1
-
+		_init_scsi_debug "${scsi_debug_params[@]}" &&
+			local zdev="/dev/${SCSI_DEBUG_DEVICES[0]}" fail &&
+			ls -ld "${zdev}" >>"${FULL}" &&
+			{ toggle_iosched & } &&
+			toggle_iosched_pid=$! &&
+			local fail &&
+			local ioengine &&
+			if [ $qd = 1 ]; then
+				ioengine=io_uring
+			else
+				ioengine=libaio
+			fi
+			local fio_args=(
+				--direct=1
+				--filename="${zdev}"
+				--iodepth="${qd}"
+				--ioengine="${ioengine}"
+				--ioscheduler=none
+				--name="requeuing-and-queue-freezing-${qd}"
+				--runtime=$((${TIMEOUT:-30}/5))
+				--rw=randwrite
+				--time_based
+				--zonemode=zbd
+			)
+		if ! fio "${fio_args[@]}" >>"${FULL}" 2>&1; then
+			fail=true
+		fi
+		if [ -n "${toggle_iosched_pid}" ]; then
+			kill "${toggle_iosched_pid}" >>"${FULL}" 2>&1
+		fi
+		_exit_scsi_debug >>"${FULL}" 2>&1
+		[ -z "$fail" ] || break
+	done
+	
 	if [ -z "$fail" ]; then
 		echo "Test complete"
 	else

--- a/tests/zbd/012.out
+++ b/tests/zbd/012.out
@@ -1,3 +1,7 @@
 Running zbd/012
 1
+2
+4
+8
+16
 Test complete


### PR DESCRIPTION
Instead of only testing queue depth 1, also test higher queue depths.
Use libaio for higher queue depths since io_uring does not preserve the
write order if qd >= 2 and a request queue is frozen.