### PR TITLE
nvme/056: Add check for empty ddp capabilities

### DIFF
--- a/tests/nvme/056
+++ b/tests/nvme/056
@@ -218,6 +218,12 @@ test() {
 	# get iface index
 	iface_idx=$(ip address | awk -F: "/${NVME_IFACE}/ { print \$1; exit; }")
 
+	# check if $(ddp_caps hw) is not empty
+	if [[ -z "$(ddp_caps hw)" ]]; then
+		SKIP_REASONS+=("No ddp capabilities found for ${NVME_IFACE}")
+		return
+	fi
+
 	# check hw supports ddp
 	if [[ $(( $(ddp_caps hw) & 3)) -ne 3 ]]; then
 		SKIP_REASONS+=("${NVME_IFACE} does not support nvme-tcp ddp offload")


### PR DESCRIPTION
Fixes a shell syntax error that occurs when trying to perform bitwise AND operation on empty ddp capabilities.
Now explicitly checks if ddp_caps hw returns empty string before proceeding with capability check.
Improves error handling for non-ddp capable devices like qemu virtio-net.

Without this patch qemu with virtio-net returns error:
```
tests/nvme/056: line 222: & 3: syntax error: operand expected (error token is "& 3")
```

With patch:
```
nvme/056 (tr=tcp) (enable zero copy offload and run rw traffic) [not run]
    runtime    ...  0.150s
    No ddp capabilities found for enp0s6
```