### PR TITLE
common/nvme: use correct local wwnn/wwpn for rport removal

### DIFF
--- a/common/nvme
+++ b/common/nvme
@@ -168,8 +168,7 @@ _cleanup_nvmet() {
 		name=$(basename "${port}")
 		echo "WARNING: Test did not clean up port: ${name}"
 		if [[ "${nvme_trtype}" == "fc" ]]; then
-			_nvme_fcloop_del_rport "$(_local_wwnn "$name")" \
-					       "$(_local_wwpn "$name")" \
+			_nvme_fcloop_del_rport "${def_local_wwnn}" "${def_local_wwpn}" \
 					       "$(_remote_wwnn "$name")" \
 					       "$(_remote_wwpn "$name")"
 			_nvme_fcloop_del_tport "$(_remote_wwnn "$name")" \


### PR DESCRIPTION
The local wwnn and wwpn don't need a port offset.

WARNING: Test did not clean up port: 0
common/nvme: line 172: _local_wwnn: command not found
common/nvme: line 172: _local_wwpn: command not found
WARNING: Test did not clean up subsystem: blktests-subsystem-1
