### PR TITLE
src/Makefile: include CFLAGS in probe macros

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,11 @@
 H := \#
 
 HAVE_C_HEADER = $(shell if echo "$(H)include <$(1)>" |		\
-		$(CC) -E - > /dev/null 2>&1; then echo "$(2)";	\
+		$(CC) $(CFLAGS) -E - > /dev/null 2>&1; then echo "$(2)";	\
 		else echo "$(3)"; fi)
 
 HAVE_C_MACRO = $(shell if echo "$(H)include <$(1)>" |	\
-		$(CC) -E - 2>&1 /dev/null | grep $(2) > /dev/null 2>&1; \
+		$(CC) $(CFLAGS) -E - 2>&1 /dev/null | grep $(2) > /dev/null 2>&1; \
 		then echo 1;else echo 0; fi)
 
 C_TARGETS := \


### PR DESCRIPTION
When cross-building we need to pass the correct paths via CFLAGS to be able to find extra libraries. We could convert to using pkg-config to resolve library availability but as the rest of the build doesn't need it we can just ensure the same CFLAGS used for building are used in the probe macros.