### PR TITLE
nvme/{043,045}: use SHA-512 DH-HMAC-CHAP keys

### DIFF
--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -34,7 +34,7 @@ test() {
 	local hostkey
 	local ctrldev
 
-	hostkey="$(nvme gen-dhchap-key -n "${def_hostnqn}" 2> /dev/null)"
+	hostkey="$(nvme gen-dhchap-key -3 -n "${def_hostnqn}" 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "nvme gen-dhchap-key failed"
 		return 1

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -38,13 +38,13 @@ test() {
 	local rand_io_size
 	local ns
 
-	hostkey="$(nvme gen-dhchap-key -n "${def_subsysnqn}" 2> /dev/null)"
+	hostkey="$(nvme gen-dhchap-key -m 3 -n "${def_subsysnqn}" 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "failed to generate host key"
 		return 1
 	fi
 
-	ctrlkey="$(nvme gen-dhchap-key -n "${def_subsysnqn}" 2> /dev/null)"
+	ctrlkey="$(nvme gen-dhchap-key -m 3 -n "${def_subsysnqn}" 2> /dev/null)"
 	if [ -z "$ctrlkey" ] ; then
 		echo "failed to generate ctrl key"
 		return 1
@@ -69,7 +69,7 @@ test() {
 
 	echo "Renew host key on the controller"
 
-	new_hostkey="$(nvme gen-dhchap-key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	new_hostkey="$(nvme gen-dhchap-key -m 3 -n "${def_subsysnqn}" 2> /dev/null)"
 
 	_set_nvmet_hostkey "${def_hostnqn}" "${new_hostkey}"
 
@@ -79,7 +79,7 @@ test() {
 
 	echo "Renew ctrl key on the controller"
 
-	new_ctrlkey="$(nvme gen-dhchap-key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	new_ctrlkey="$(nvme gen-dhchap-key -m 3 -n "${def_subsysnqn}" 2> /dev/null)"
 
 	_set_nvmet_ctrlkey "${def_hostnqn}" "${new_ctrlkey}"
 


### PR DESCRIPTION
We really should not use keys with a length smaller than the hash length as otherwise we would not have enough key data to satisfy security constrains. So update tests to use SHA-512 keys to ensure we always have a large enough key.