### PR TITLE
common/scsi_debug: Use _unload_module in _exit_scsi_debug

### DIFF
--- a/common/scsi_debug
+++ b/common/scsi_debug
@@ -180,7 +180,7 @@ _exit_scsi_debug() {
 	udevadm settle
 
 	if _module_file_exists scsi_debug; then
-		modprobe -r scsi_debug
+		_unload_module scsi_debug 10
 		return
 	fi
 


### PR DESCRIPTION
It may fails with modprobe -r scsi-debug during stress block/037 test, fix it by using _unload_module instead of modprobe -r.

==================3350
block/037 (test cgroup vs. scsi_debug rebind)                [failed]
    runtime  0.612s  ...  0.501s
    --- tests/block/037.out	2025-05-27 02:53:20.099293638 -0400
    +++ /root/blktests/results/nodev/block/037.out.bad	2025-05-27 06:19:51.200678129 -0400
    @@ -1,2 +1,4 @@
     Running block/037
    +modprobe: FATAL: Module scsi_debug is in use.
    +scsi_debug            172032  1
     Test complete