### PR TITLE
nvme: Add test for sending admin commands over disabled paths

### DIFF
--- a/tests/nvme/064
+++ b/tests/nvme/064
@@ -1,0 +1,53 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0+
+# Copyright (C) 2024 Hannes Reinecke (SUSE) <hare@suse.de>
+#
+# Test nvme fabrics controller ANA failover during I/O
+
+. tests/nvme/rc
+
+DESCRIPTION="test admin commands on disabled paths"
+
+requires() {
+	_nvme_requires
+	_have_loop
+	_have_fio
+	_require_nvme_trtype_is_fabrics
+}
+
+set_conditions() {
+	_set_nvme_trtype "$@"
+}
+
+test() {
+	local -a ports
+	local port
+	local ns
+
+	echo "Running ${TEST_NAME}"
+
+	_setup_nvmet
+
+	_nvmet_target_setup
+
+	_nvme_connect_subsys
+
+	ns=$(_find_nvme_ns "${def_subsys_uuid}")
+	[ -z "${ns}" ] && return 1
+	nvme nvm-id-ctrl "/dev/${ns}"
+	nvme nvm-id-ns "/dev/${ns}"
+
+	# switch to ANA inaccessible
+	_get_nvmet_ports "${def_subsysnqn}" ports
+	for port in $ports; do
+		_setup_nvmet_port_ana "${port}" 1 "inaccessible"
+	done
+
+	nvme nvm-id-ctrl "/dev/${ns}"
+	nvme nvm-id-ns "/dev/${ns}" 2> /dev/null || true
+
+	_nvme_disconnect_subsys
+	_nvmet_target_cleanup
+
+	echo "Test complete"
+}

--- a/tests/nvme/064.out
+++ b/tests/nvme/064.out
@@ -1,0 +1,21 @@
+Running nvme/064
+NVMe Identify Controller NVM:
+vsl    : 0
+wzsl   : 0
+wusl   : 0
+dmrl   : 0
+dmrsl  : 0
+dmsl   : 0
+NVMe NVM Identify Namespace 1:
+lbstm : 0
+pic   : 0
+elbaf  0 : pif:0 sts:0  (in use)
+NVMe Identify Controller NVM:
+vsl    : 0
+wzsl   : 0
+wusl   : 0
+dmrl   : 0
+dmrsl  : 0
+dmsl   : 0
+disconnected 1 controller(s)
+Test complete


### PR DESCRIPTION
ANA states only apply to commands to individual namespaces, not to commands for the controller. So add a testcase to check if we can send admin commands over inaccessible paths.