### PR TITLE
common/rc: add _have_crypto()

### DIFF
--- a/common/rc
+++ b/common/rc
@@ -68,6 +68,30 @@ _have_driver()
 	return 0
 }
 
+# Check that the specified crypto algorithm is present, regardless of
+# whether it's build-in, a module, or provided by the kernel.
+# The module will be loaded if it is loadable, and unloaded at test case end.
+_have_crypto()
+{
+	local modname="${1//-/_}"
+
+	if [ -d "/sys/module/${modname}" ]; then
+		return 0
+	fi
+
+	if ! modprobe -q "${modname}"; then
+		if ! grep -q "${modname}" /proc/crypto; then
+			SKIP_REASONS+=("driver ${modname} is not available")
+			return 1
+		fi
+		return 0
+	fi
+
+	MODULES_TO_UNLOAD+=("${modname}")
+
+	return 0
+}
+
 # Check that the specified module is available as a loadable module and not
 # built-in the kernel.
 _have_module() {

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -17,7 +17,7 @@ requires() {
 	_require_kernel_nvme_fabrics_feature dhchap_ctrl_secret
 	_require_nvme_trtype_is_fabrics
 	_require_nvme_cli_auth
-	_have_driver dh_generic
+	_have_crypto dh_generic
 }
 
 set_conditions() {

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -17,7 +17,7 @@ requires() {
 	_require_kernel_nvme_fabrics_feature dhchap_ctrl_secret
 	_require_nvme_trtype_is_fabrics
 	_require_nvme_cli_auth
-	_have_driver dh_generic
+	_have_crypto dh_generic
 }
 
 set_conditions() {

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -18,7 +18,7 @@ requires() {
 	_require_kernel_nvme_fabrics_feature dhchap_ctrl_secret
 	_require_nvme_trtype_is_fabrics
 	_require_nvme_cli_auth
-	_have_driver dh_generic
+	_have_crypto dh_generic
 }
 
 set_conditions() {


### PR DESCRIPTION
Add a function _have_crypto() to check if a specific crypto algorithm is present. Some cryptographic function are implemented directly in the kernel, so a simple '_have_driver' doesn't work here.