### PR TITLE
md/002: use --run option instead of "echo y"

### DIFF
--- a/tests/md/002
+++ b/tests/md/002
@@ -73,12 +73,12 @@ test() {
 	for raid_level in 0 1 10; do
 		if [ "$raid_level" = 10 ]
 		then
-			echo y | mdadm --create /dev/md/blktests_md --level=$raid_level \
-				--raid-devices=4 --force /dev/"${scsi_0}" /dev/"${scsi_1}" \
+			mdadm --create /dev/md/blktests_md --level=$raid_level \
+				--raid-devices=4 --force --run /dev/"${scsi_0}" /dev/"${scsi_1}" \
 				/dev/"${scsi_2}" /dev/"${scsi_3}" 2> /dev/null 1>&2
 		else
-			echo y | mdadm --create /dev/md/blktests_md --level=$raid_level \
-				--raid-devices=2 --force \
+			mdadm --create /dev/md/blktests_md --level=$raid_level \
+				--raid-devices=2 --force --run \
 				/dev/"${scsi_0}" /dev/"${scsi_1}" 2> /dev/null 1>&2
 		fi
 
@@ -214,12 +214,12 @@ test() {
 
 			if [ "$raid_level" = 0 ]
 			then
-				echo y | mdadm --create /dev/md/blktests_md --level=$raid_level \
-					--raid-devices=2 --chunk="${md_chunk_size}"K --force \
+				mdadm --create /dev/md/blktests_md --level=$raid_level \
+					--raid-devices=2 --chunk="${md_chunk_size}"K --force --run \
 					/dev/"${scsi_0}" /dev/"${scsi_1}" 2> /dev/null 1>&2
 			else
-				echo y | mdadm --create /dev/md/blktests_md --level=$raid_level \
-					--raid-devices=4 --chunk="${md_chunk_size}"K --force \
+				mdadm --create /dev/md/blktests_md --level=$raid_level \
+					--raid-devices=4 --chunk="${md_chunk_size}"K --force --run \
 					/dev/"${scsi_0}" /dev/"${scsi_1}" \
 					/dev/"${scsi_2}" /dev/"${scsi_3}" 2> /dev/null 1>&2
 			fi


### PR DESCRIPTION
When mdadm creates a new array, it asks questions to users in the console, which is not suitable for automated test script runs. Then the test case md/002 used "echo y" with pipe to answer the questions automatically.

However, starting with mdadm version 4.4, the "echo y" approach no longer works effectively, especially after a commit which introduced a new question [1]. This caused the test case failure.

[1] https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/?h=main&id=e97c4e18c847803016aa60066cb6e57c528d83a6

The --run option is now the recommended alternative because it directly bypasses the questions. To avoid the failure, add the "--run" option to the mdadm create commands instead of the "echo y".

Link: https://github.com/linux-blktests/blktests/issues/201