### PR TITLE
md/002: ignore the "File descripto leaked" log from vgdisplay

### DIFF
--- a/tests/md/rc
+++ b/tests/md/rc
@@ -92,7 +92,7 @@ declare -A MD_DEVICES
 _get_vgsize() {
 	local vgsize
 
-	vgsize=$(vgdisplay --units b blktests_vg00 | grep 'VG Size' | tr -d -c 0-9)
+	vgsize=$(vgdisplay --units b blktests_vg00 2> /dev/null | grep 'VG Size' | tr -d -c 0-9)
 	echo "$vgsize"
 }
 


### PR DESCRIPTION
$ ./check md/002
md/002 (test md atomic writes)                               [failed]
    runtime  16.597s  ...  16.621s
    --- tests/md/002.out	2025-11-11 03:27:25.669051094 +0000
    +++ /root/blktests/results/nodev/md/002.out.bad	2025-11-11 04:21:41.669796053 +0000
    @@ -116,6 +116,7 @@
     TEST 10 raid10 step 4 - perform a pwritev2 with size of sysfs_atomic_unit_min_bytes with RWF_ATOMIC flag - pwritev2 should fail - pass
     pwrite: Invalid argument
     TEST 11 raid10 step 4 - perform a pwritev2 with a size of sysfs_atomic_write_unit_max_bytes - LBS bytes with RWF_ATOMIC flag - pwritev2 should fail - pass
    +File descriptor 3 (/dev/z90crypt) leaked on vgdisplay invocation. Parent PID 30154: /bin/bash
     TEST 1 dm-linear step 1 - Verify md sysfs atomic attributes matches - pass
     TEST 2 dm-linear step 1 - Verify sysfs atomic attributes - pass
     TEST 3 dm-linear step 1 - Verify md sysfs_atomic_write_max is equal to expected_atomic_write_max - pass

Link: https://github.com/linux-blktests/blktests/issues/209