### PR TITLE
zbd/012, block/041, scsi/008: enable io_uring if it's disabled

### DIFF
--- a/tests/block/041
+++ b/tests/block/041
@@ -48,6 +48,9 @@ test_device() {
 	bs=$(_min_io "$TEST_DEV")
 	md_per_io_size=$((bs * lbmd_size / lbmd_interval))
 
+	# enable io_uring when it is disabled
+	_io_uring_enable
+
 	local fio_args=(
 		--name=pi_read_test
 		--filename="$TEST_DEV"
@@ -67,5 +70,9 @@ test_device() {
 	)
 
 	_run_fio "${fio_args[@]}"
+
+	# reset io_uring setting before exits test
+	_io_uring_restore
+
 	echo "Test complete"
 }

--- a/tests/scsi/008
+++ b/tests/scsi/008
@@ -61,6 +61,10 @@ test() {
 	local scsi_debug_params=(
 		delay=0
 	)
+
+	# enable io_uring when it is disabled
+	_io_uring_enable
+
 	_configure_scsi_debug "${scsi_debug_params[@]}" &&
 	local dev="/dev/${SCSI_DEBUG_DEVICES[0]}" fail &&
 	ls -ldi "${dev}" >>"${FULL}" &&
@@ -71,6 +75,9 @@ test() {
 	fail=true
 
 	_exit_scsi_debug
+
+	# reset io_uring setting before exits test
+	_io_uring_restore
 
 	if [ -z "$fail" ]; then
 		echo "Test complete"

--- a/tests/zbd/012
+++ b/tests/zbd/012
@@ -29,6 +29,9 @@ toggle_iosched() {
 test() {
 	echo "Running ${TEST_NAME}"
 
+	# enable io_uring when it is disabled
+	_io_uring_enable
+
 	for qd in 1 2 4 8 16; do
 		echo "$qd"
 		local scsi_debug_params=(
@@ -74,6 +77,9 @@ test() {
 		_exit_scsi_debug >>"${FULL}" 2>&1
 		[ -z "$fail" ] || break
 	done
+
+	# reset io_uring setting before exits test
+	_io_uring_restore
 
 	if [ -z "$fail" ]; then
 		echo "Test complete"


### PR DESCRIPTION
The fio test need ioengine=io_uring, enable it for fio