### PR TITLE
common/nvme: remove allowed_hosts before remove subsys in nvmet configfs

### DIFF
--- a/common/nvme
+++ b/common/nvme
@@ -196,6 +196,9 @@ _cleanup_nvmet() {
 		for ns in "${subsys}"/namespaces/*; do
 			rmdir "${ns}"
 		done
+		for allowed_host in "${subsys}"/allowed_hosts/*; do
+			rm -f "$allowed_host"
+		done
 		rmdir "${subsys}"
 	done
 


### PR DESCRIPTION
$ nvme_trtype=tcp ./check nvme/063
nvme/063 (tr=tcp) (Create authenticated TCP connections with secure concatenation)
    runtime  2.220s  ...
WARNING: Test did not clean up port: 0
nvme/063 (tr=tcp) (Create authenticated TCP connections with secure concatenation) [failed]
    runtime  2.220s  ...  2.217sost: nqn.2014-08.org.nvmexpress:uuid:0f01fb42-9f7f-4856-b0b3-51e60b8de349
    --- tests/nvme/063.out	2025-11-02 02:47:38.826227836 -0500
    +++ /root/blktests/results/nodev_tr_tcp/nvme/063.out.bad	2025-11-02 08:43:09.743150576 -0500
    @@ -1,7 +1,3 @@
     Running nvme/063
     Test secure concatenation with SHA256
    -Reset controller
    -disconnected 1 controller(s)
    -Test secure concatenation with SHA384
    -disconnected 1 controller(s)
    -Test complete
    ...
    (Run 'diff -u tests/nvme/063.out /root/blktests/results/nodev_tr_tcp/nvme/063.out.bad' to see the entire diff)

Link: https://github.com/linux-blktests/blktests/issues/207