### PR TITLE
common/rc: add _have_crypto_algorithm

### DIFF
--- a/common/rc
+++ b/common/rc
@@ -69,6 +69,19 @@ _have_driver()
 	return 0
 }
 
+# Check that the specified crypto algorithm is present, regardless of whether
+# it's built-in or as module.
+_have_crypto_algorithm()
+{
+	local algo="$1"
+
+	if grep -q "${algo}" /proc/crypto; then
+		return 0
+	fi
+
+	_have_driver "${algo}"
+}
+
 # Check that the specified module is available as a loadable module and not
 # built-in the kernel.
 _have_module() {

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -16,7 +16,7 @@ requires() {
 	_require_kernel_nvme_fabrics_feature dhchap_ctrl_secret
 	_require_nvme_trtype_is_fabrics
 	_require_nvme_cli_auth
-	_have_driver dh_generic
+	_have_crypto_algorithm dh-generic
 }
 
 set_conditions() {

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -16,7 +16,7 @@ requires() {
 	_require_kernel_nvme_fabrics_feature dhchap_ctrl_secret
 	_require_nvme_trtype_is_fabrics
 	_require_nvme_cli_auth
-	_have_driver dh_generic
+	_have_crypto_algorithm dh-generic
 }
 
 set_conditions() {

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -17,7 +17,7 @@ requires() {
 	_require_kernel_nvme_fabrics_feature dhchap_ctrl_secret
 	_require_nvme_trtype_is_fabrics
 	_require_nvme_cli_auth
-	_have_driver dh_generic
+	_have_crypto_algorithm dh-generic
 }
 
 set_conditions() {


### PR DESCRIPTION
A crypto algorithm might be provided as built-in, thus check first if it is always present before trying to load as module.

The idea to check the CONFIG flags is not enough. The algorithm needs to be present in the kernel. `/proc/crypto` has all the info. `/sys/modules/*` will not show built-in modules.

Fixes: #https://github.com/linux-blktests/blktests/issues/197
Replaces: #https://github.com/linux-blktests/blktests/pull/198