### PR TITLE
check `nvme connect` return codes

### DIFF
--- a/common/nvme
+++ b/common/nvme
@@ -285,6 +285,7 @@ _nvme_connect_subsys() {
 	local ctrl_loss_tmo=""
 	local no_wait=false
 	local no_wait_ns=false
+	local expect_failure=false
 	local hdr_digest=false
 	local data_digest=false
 	local tls=false
@@ -350,6 +351,10 @@ _nvme_connect_subsys() {
 				;;
 			--no-wait-ns)
 				no_wait_ns=true
+				shift 1
+				;;
+			--expect-failure)
+				expect_failure=true
 				shift 1
 				;;
 			--hdr-digest)
@@ -433,6 +438,16 @@ _nvme_connect_subsys() {
 	fi
 	ARGS+=(--output-format=json)
 	connect=$(nvme connect "${ARGS[@]}" 2> /dev/null)
+	ret=$?
+	if [[ ${expect_failure} = false ]]; then
+		if [[ ${ret} != 0 ]]; then
+		   echo "FAIL: nvme connect return error code"
+		fi
+	else
+		if [[ ${ret} == 0 ]]; then
+		   echo "FAIL: nvme connect did not return error code"
+		fi
+	fi
 
 	# Wait until device file and sysfs attributes get ready
 	if [[ ${no_wait} = false ]]; then

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -40,7 +40,7 @@ test() {
 
 	# Test unauthenticated connection (should fail)
 	echo "Test unauthenticated connection (should fail)"
-	_nvme_connect_subsys --no-wait
+	_nvme_connect_subsys --no-wait --expect-failure
 
 	_nvme_disconnect_subsys
 

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -59,7 +59,8 @@ test() {
 	# and invalid ctrl authentication
 	echo "Test invalid ctrl authentication (should fail)"
 	_nvme_connect_subsys --dhchap-secret "${hostkey}" \
-			     --dhchap-ctrl-secret "${hostkey}" --no-wait
+			     --dhchap-ctrl-secret "${hostkey}" \
+				 --no-wait --expect-failure
 
 	_nvme_disconnect_subsys
 
@@ -76,7 +77,8 @@ test() {
 	echo "Test invalid ctrl key (should fail)"
 	invkey="DHHC-1:00:Jc/My1o0qtLCWRp+sHhAVafdfaS7YQOMYhk9zSmlatobqB8C:"
 	_nvme_connect_subsys --dhchap-secret "${hostkey}" \
-			     --dhchap-ctrl-secret "${invkey}" --no-wait
+			     --dhchap-ctrl-secret "${invkey}" \
+				 --no-wait --expect-failure
 
 	_nvme_disconnect_subsys
 

--- a/tests/nvme/047
+++ b/tests/nvme/047
@@ -31,8 +31,7 @@ test() {
 
 	_nvmet_target_setup
 
-	_nvme_connect_subsys \
-		--nr-write-queues 1 || echo FAIL
+	_nvme_connect_subsys --nr-write-queues 1
 
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 
@@ -41,9 +40,7 @@ test() {
 
 	_nvme_disconnect_subsys >> "$FULL" 2>&1
 
-	_nvme_connect_subsys \
-		--nr-write-queues 1 \
-		--nr-poll-queues 1 || echo FAIL
+	_nvme_connect_subsys --nr-write-queues 1 --nr-poll-queues 1
 
 	_run_fio_rand_io --filename="/dev/${ns}" --size="${rand_io_size}"
 

--- a/tests/nvme/062
+++ b/tests/nvme/062
@@ -71,7 +71,7 @@ test() {
 
 	# Test unencrypted connection
 	echo "Test unencrypted connection w/ tls required (should fail)"
-	_nvme_connect_subsys --no-wait
+	_nvme_connect_subsys --no-wait --expect-failure
 
 	_nvme_disconnect_subsys
 


### PR DESCRIPTION
Increase test coverage by checking if `nvme connect` is also reporting the expected return code.

At least nvme/031 seems to trigger sometimes FAILs.

To my surprise, nvme/041 for FC is passing with https://lore.kernel.org/linux-nvme/20251117184343.97605-1-justintee8345@gmail.com/  applied. Nice :)