### PR TITLE
Skip tests if scsi_debug module is already loaded and in use

### DIFF
--- a/common/scsi_debug
+++ b/common/scsi_debug
@@ -4,12 +4,33 @@
 #
 # scsi_debug helper functions.
 
-_have_scsi_debug() {
-	_have_driver scsi_debug
-}
-
 SD_PARAM_PATH=/sys/module/scsi_debug/parameters
 SD_PSEUDO_PATH=/sys/bus/pseudo/drivers/scsi_debug
+
+_have_scsi_debug() {
+	_have_driver scsi_debug
+
+	if _module_file_exists scsi_debug; then
+		_have_loadable_scsi_debug
+		return $?
+	fi
+
+	if [[ -e "$SD_PSEUDO_PATH/add_host" ]] && \
+		[[ $(cat "$SD_PSEUDO_PATH/add_host") -gt 1 ]]; then
+			SKIP_REASONS+=("scsi_debug already has multiple hosts configured")
+			return 1
+	fi
+}
+
+_have_loadable_scsi_debug() {
+	_have_module scsi_debug || return 1
+
+	if [[ -d /sys/module/scsi_debug ]] && \
+		[[ ! ${MODULES_TO_UNLOAD[*]} =~ scsi_debug ]]; then
+			SKIP_REASONS+=("scsi_debug is already loaded before test")
+			return 1
+	fi
+}
 
 _scsi_debug_key_path() {
 	local key=${1}

--- a/tests/block/009
+++ b/tests/block/009
@@ -12,7 +12,7 @@
 DESCRIPTION="check page-cache coherency after BLKDISCARD"
 
 requires() {
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 	_have_program xfs_io
 }
 

--- a/tests/block/025
+++ b/tests/block/025
@@ -12,7 +12,7 @@
 DESCRIPTION="do a huge discard with 4k sector size"
 
 requires() {
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 }
 
 test() {

--- a/tests/block/028
+++ b/tests/block/028
@@ -12,7 +12,7 @@ DESCRIPTION="do I/O on scsi_debug with DIF/DIX enabled"
 DMESG_FILTER="sed -r 's/(guard tag error at sector|ref tag error at location)/blktests failure: \\1/'"
 
 requires() {
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 }
 
 test_pi() {

--- a/tests/block/032
+++ b/tests/block/032
@@ -14,7 +14,7 @@ QUICK=1
 
 requires() {
 	_have_xfs
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 }
 
 test() {

--- a/tests/loop/004
+++ b/tests/loop/004
@@ -12,7 +12,7 @@ QUICK=1
 
 requires() {
 	_have_program xfs_io
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 	_have_src_program loblksize
 	_have_loop_set_block_size
 }

--- a/tests/md/002
+++ b/tests/md/002
@@ -12,7 +12,7 @@ DESCRIPTION="test md atomic writes"
 QUICK=1
 
 requires() {
-	_have_driver scsi_debug
+	_have_scsi_debug
 	_stacked_atomic_test_requires
 }
 

--- a/tests/scsi/007
+++ b/tests/scsi/007
@@ -12,7 +12,7 @@ DESCRIPTION="Trigger the SCSI error handler"
 QUICK=1
 
 requires() {
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 }
 
 start_tracing() {

--- a/tests/scsi/009
+++ b/tests/scsi/009
@@ -12,7 +12,7 @@ DESCRIPTION="test scsi atomic writes"
 QUICK=1
 
 requires() {
-	_have_driver scsi_debug
+	_have_scsi_debug
 	_have_xfs_io_atomic_write
 }
 

--- a/tests/srp/rc
+++ b/tests/srp/rc
@@ -58,7 +58,7 @@ group_requires() {
 		_have_kver 5 5
 		_have_iproute2 190404
 	fi
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 	_have_module target_core_iblock
 	_have_module target_core_mod
 	_module_not_in_use scsi_transport_srp

--- a/tests/zbd/008
+++ b/tests/zbd/008
@@ -13,7 +13,7 @@ DESCRIPTION="check no stale page cache after BLKZONERESET and data read race"
 TIMED=1
 
 requires() {
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 	_have_module_param scsi_debug zbc
 	_have_program xfs_io
 }

--- a/tests/zbd/009
+++ b/tests/zbd/009
@@ -36,7 +36,7 @@ requires() {
 	_have_driver btrfs
 	_have_module_param scsi_debug zone_cap_mb
 	_have_program mkfs.btrfs && have_good_mkfs_btrfs
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 }
 
 test() {

--- a/tests/zbd/010
+++ b/tests/zbd/010
@@ -15,7 +15,7 @@ requires() {
 	_have_module null_blk
 	_have_module_param scsi_debug zone_cap_mb
 	_have_program mkfs.f2fs
-	_have_module scsi_debug
+	_have_loadable_scsi_debug
 }
 
 test() {


### PR DESCRIPTION
Several tests across block/, scsi/, dm/, md/, zbd/, nvme/ require exclusive access to the scsi_debug module because they load, unload or reconfigure it. When scsi_debug is already loaded by the environment (e.g., by another driver or a previous setup), these tests fail with:
```
modprobe: FATAL: Module scsi_debug is in use.
Unloading scsi_debug failed
```

```
# lsmod | grep scsi_debug
scsi_debug            327680  4
```
Instead of modifying common rc files—which would overskip unrelated tests, this patch adds `_module_not_in_use scsi_debug` only to the tests that actually depend on exclusive access to scsi_debug.