### PR TITLE
nvme: Test a large metadata_len

### DIFF
--- a/src/nvme-passthrough-meta.c
+++ b/src/nvme-passthrough-meta.c
@@ -228,5 +228,13 @@ int main(int argc, char **argv)
 		return EFAULT;
 	}
 
+	cmd.opcode = 1;
+	cmd.metadata_len = 4096 * 20;
+	ret = ioctl(fd, NVME_IOCTL_IO_CMD, &cmd);
+	if (ret == 0) {
+			perror("nvme-write (large metadata_len)");
+			return EFAULT;
+	}
+
 	return 0;
 }


### PR DESCRIPTION
This reproduces a kernel bug[1] that triggers a general protection fault.

The kernel pins a user memory `metadata`, which can partially succeed. However, the kernel (`bio_integrity_map_user()`) does not handle partial pinning and assumes that all requested memory is pinned, leading to a null-ptr-deref.

To reproduce this, this testcase makes the kernel partially pin the requested memory by requesting arbitrary large `metadata_len`. In my setting, `metadata_len=20 * 4096` was enough to trigger partial pinning, though the trigger depends on the machine. If a testing machine uses a large page (e.g., 1GB), then it cannot trigger the partial pinning.

[1] https://lore.kernel.org/linux-block/20260427040926.987166-3-iam@sung-woo.kim/T/#u