### PR TITLE
nvme/059: fix unset bytes_to_write in TEST 7

### DIFF
--- a/tests/nvme/059
+++ b/tests/nvme/059
@@ -134,6 +134,7 @@ test_device() {
 
 	test_desc="TEST 7 - perform a pwritev2 with size of sysfs_atomic_unit_max_bytes + logical "
 	test_desc+="block with RWF_ATOMIC flag - pwritev2 should not be successful"
+	bytes_to_write=$(( sysfs_atomic_unit_max_bytes + sysfs_logical_block_size ))
 	bytes_written=$(run_xfs_io_pwritev2_atomic /dev/"$ns_dev" "$bytes_to_write")
 	if [ "$bytes_written" = "" ]
 	then

--- a/tests/nvme/059.out
+++ b/tests/nvme/059.out
@@ -5,5 +5,6 @@ TEST 3 - Verify statx is correctly reporting atomic_unit_max_bytes - pass
 TEST 4 - Verify statx is correctly reporting atomic_unit_min_bytes - pass
 TEST 5 - perform a pwritev2 with size of sysfs_atomic_unit_min_bytes with RWF_ATOMIC flag - pwritev2 should  be successful - pass
 TEST 6 - perform a pwritev2 with size of sysfs_atomic_unit_max_bytes with RWF_ATOMIC flag - pwritev2 should  be successful - pass
+pwrite: Invalid argument
 TEST 7 - perform a pwritev2 with size of sysfs_atomic_unit_max_bytes + logical block with RWF_ATOMIC flag - pwritev2 should not be successful - pass
 Test complete


### PR DESCRIPTION
bytes_to_write was never assigned, causing TEST 7 to pass for the wrong reason. Set it to atomic_unit_max_bytes + logical_block_size and update the golden output with the expected "pwrite: Invalid argument" from xfs_io.