### PR TITLE
Handle nvme cli 3.x output changes

### DIFF
--- a/common/nvme
+++ b/common/nvme
@@ -264,23 +264,52 @@ _setup_nvmet() {
 
 _nvme_disconnect_ctrl() {
 	local ctrl="$1"
+	local subsysnqn="$def_subsysnqn"
+	local no_wait=false
 
-	nvme disconnect --device "${ctrl}"
-}
+	shift
 
-_nvme_disconnect_ctrl_sync() {
-	local ctrl="$1"
-	local subsysnqn="$2"
-
-	_nvme_disconnect_ctrl "${ctrl}"
-
-	for ((i = 0; i < 10; i++)); do
-		_nvme_ctrl_ready "${ctrl}" "${subsysnqn}"
-		if [[ $? -eq 1 ]]; then
-			break
-		fi
-		sleep .1
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			--subsysnqn)
+				subsysnqn="$2"
+				shift 2
+				;;
+			--no-wait)
+				no_wait=true
+				shift 1
+				;;
+			*)
+				echo "WARNING: unknown argument: $1"
+				shift
+				;;
+		esac
 	done
+
+	local ctrl_dir="/sys/class/nvme/${ctrl}"
+	if [[ -d "${ctrl_dir}" ]]; then
+		local ret
+
+		nvme disconnect --device "${ctrl}" &> "${FULL}"
+		ret=$?
+		if [[ ${ret} -ne 0 ]]; then
+			echo "FAIL: nvme disconnect returned error code: ${ret}"
+		fi
+
+		if [[ ${no_wait} = false ]]; then
+			for ((i = 0; i < 10; i++)); do
+				_nvme_ctrl_ready "${ctrl}" "${subsysnqn}"
+				if [[ $? -eq 1 ]]; then
+					break
+				fi
+				sleep .1
+			done
+		else
+			if [[ -d "${ctrl_dir}" ]]; then
+				echo "FAIL: Controller ${ctrl} still exists after disconnect"
+			fi
+		fi
+	fi
 }
 
 _nvme_wait_subsys_removed() {
@@ -291,13 +320,19 @@ _nvme_wait_subsys_removed() {
 		if [ "$subsysnqn" == "$_subsysnqn" ]; then
 			for ((i = 0; i < 10; i++)); do
 				if [ ! -d "$subsyspath" ]; then
-					break
+					return 0
 				fi
 				sleep .1
 			done
-			break
+
+			if [ -d "$subsyspath" ]; then
+				return 1
+			fi
+			return 0
 		fi
 	done
+
+	return 0
 }
 
 _nvme_connect_subsys() {
@@ -503,6 +538,7 @@ _nvme_connect_subsys() {
 
 _nvme_disconnect_subsys() {
 	local subsysnqn="$def_subsysnqn"
+	local ret
 
 	while [[ $# -gt 0 ]]; do
 		case $1 in
@@ -517,8 +553,15 @@ _nvme_disconnect_subsys() {
 		esac
 	done
 
-	nvme disconnect --nqn "${subsysnqn}" |& tee -a "$FULL" |
-		grep -o "disconnected.*"
+	nvme disconnect --nqn "${subsysnqn}" &> "${FULL}"
+	ret=$?
+	if [[ ${ret} -ne 0 ]]; then
+		echo "FAIL: nvme disconnect returned error code: ${ret}"
+	fi
+
+	if ! _nvme_wait_subsys_removed "${subsysnqn}"; then
+		echo "FAIL: subsystem sysfs entry still exits"
+	fi
 }
 
 _nvme_ctrl_ready() {

--- a/tests/md/001.out
+++ b/tests/md/001.out
@@ -1,3 +1,2 @@
 Running md/001
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/003.out
+++ b/tests/nvme/003.out
@@ -1,3 +1,2 @@
 Running nvme/003
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/004.out
+++ b/tests/nvme/004.out
@@ -1,3 +1,2 @@
 Running nvme/004
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/008.out
+++ b/tests/nvme/008.out
@@ -1,3 +1,2 @@
 Running nvme/008
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/010.out
+++ b/tests/nvme/010.out
@@ -1,3 +1,2 @@
 Running nvme/010
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/012.out
+++ b/tests/nvme/012.out
@@ -1,3 +1,2 @@
 Running nvme/012
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/014
+++ b/tests/nvme/014
@@ -28,6 +28,7 @@ test() {
 	local size
 	local bs
 	local count
+	local ret
 
 	_nvmet_target_setup
 
@@ -42,7 +43,11 @@ test() {
 	dd if=/dev/urandom of="/dev/${ns}" \
 		count="${count}" bs="${bs}" status=none
 
-	nvme flush "/dev/${ns}"
+	nvme flush "/dev/${ns}" &> "${FULL}"
+	ret=$?
+	if [[ ${ret} -ne 0 ]]; then
+		echo "FAIL: nvme flush return error code: $(ret)"
+	fi
 
 	_nvme_disconnect_subsys
 

--- a/tests/nvme/014.out
+++ b/tests/nvme/014.out
@@ -1,3 +1,2 @@
 Running nvme/014
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/014.out
+++ b/tests/nvme/014.out
@@ -1,4 +1,3 @@
 Running nvme/014
-NVMe Flush: success
 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/018.out
+++ b/tests/nvme/018.out
@@ -1,3 +1,2 @@
 Running nvme/018
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/019
+++ b/tests/nvme/019
@@ -24,6 +24,7 @@ test() {
 
 	_setup_nvmet
 
+	local ret
 	local ns
 	local nblk_range="10,10,10,10,10,10,10,10,10,10"
 	local sblk_range="100,200,300,400,500,600,700,800,900,1000"
@@ -33,8 +34,14 @@ test() {
 	_nvme_connect_subsys
 
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
+
 	nvme dsm "/dev/${ns}" --ad \
-		--slbs "${sblk_range}" --blocks "${nblk_range}"
+			--slbs "${sblk_range}" \
+			--blocks "${nblk_range}" &> "${FULL}"
+	ret=$?
+	if [[ ${ret} -ne 0 ]]; then
+		echo "FAIL: nvme dsm return error code: $(ret)"
+	fi
 
 	_nvme_disconnect_subsys
 

--- a/tests/nvme/019.out
+++ b/tests/nvme/019.out
@@ -1,3 +1,2 @@
 Running nvme/019
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/019.out
+++ b/tests/nvme/019.out
@@ -1,4 +1,3 @@
 Running nvme/019
-NVMe DSM: success
 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/033.out
+++ b/tests/nvme/033.out
@@ -1,3 +1,2 @@
 Running nvme/033
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/034.out
+++ b/tests/nvme/034.out
@@ -1,3 +1,2 @@
 Running nvme/034
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/035.out
+++ b/tests/nvme/035.out
@@ -1,3 +1,2 @@
 Running nvme/035
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/036.out
+++ b/tests/nvme/036.out
@@ -1,3 +1,2 @@
 Running nvme/036
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/041.out
+++ b/tests/nvme/041.out
@@ -1,6 +1,4 @@
 Running nvme/041
 Test unauthenticated connection (should fail)
-disconnected 0 controller(s)
 Test authenticated connection
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/042.out
+++ b/tests/nvme/042.out
@@ -1,16 +1,9 @@
 Running nvme/042
 Testing hmac 0
-disconnected 1 controller(s)
 Testing hmac 1
-disconnected 1 controller(s)
 Testing hmac 2
-disconnected 1 controller(s)
 Testing hmac 3
-disconnected 1 controller(s)
 Testing key length 32
-disconnected 1 controller(s)
 Testing key length 48
-disconnected 1 controller(s)
 Testing key length 64
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/043.out
+++ b/tests/nvme/043.out
@@ -1,18 +1,10 @@
 Running nvme/043
 Testing hash hmac(sha256)
-disconnected 1 controller(s)
 Testing hash hmac(sha384)
-disconnected 1 controller(s)
 Testing hash hmac(sha512)
-disconnected 1 controller(s)
 Testing DH group ffdhe2048
-disconnected 1 controller(s)
 Testing DH group ffdhe3072
-disconnected 1 controller(s)
 Testing DH group ffdhe4096
-disconnected 1 controller(s)
 Testing DH group ffdhe6144
-disconnected 1 controller(s)
 Testing DH group ffdhe8192
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/044.out
+++ b/tests/nvme/044.out
@@ -1,10 +1,6 @@
 Running nvme/044
 Test host authentication
-disconnected 1 controller(s)
 Test invalid ctrl authentication (should fail)
-disconnected 0 controller(s)
 Test valid ctrl authentication
-disconnected 1 controller(s)
 Test invalid ctrl key (should fail)
-disconnected 0 controller(s)
 Test complete

--- a/tests/nvme/045.out
+++ b/tests/nvme/045.out
@@ -8,5 +8,4 @@ Change DH group to ffdhe8192
 Re-authenticate with changed DH group
 Change hash to hmac(sha512)
 Re-authenticate with changed hash
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/048.out
+++ b/tests/nvme/048.out
@@ -1,3 +1,2 @@
 Running nvme/048
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/054
+++ b/tests/nvme/054
@@ -27,6 +27,16 @@ resv_report() {
 		grep -E "gen|rtype|regctl|regctlext|cntlid|rcsts|rkey"
 }
 
+nvme_resv() {
+	local cmd=$1
+	local test_dev=$2
+	shift 2
+	if ! nvme resv-"${cmd}" "$test_dev" "$@" >>"${FULL}" 2>&1; then
+		echo "FAIL: nvme resv-${cmd} failed on $test_dev with args: $*"
+		return 1
+	fi
+}
+
 test_resv() {
 	local ns=$1
 	local report_arg="--cdw11=1"
@@ -38,34 +48,34 @@ test_resv() {
 
 	echo "Register"
 	resv_report "${test_dev}" "${report_arg}"
-	nvme resv-register "${test_dev}" --nrkey=4 --rrega=0
+	nvme_resv register "${test_dev}" --nrkey=4 --rrega=0
 	resv_report "${test_dev}" "${report_arg}"
 
 	echo "Replace"
-	nvme resv-register "${test_dev}" --crkey=4 --nrkey=5 --rrega=2
+	nvme_resv register "${test_dev}" --crkey=4 --nrkey=5 --rrega=2
 	resv_report "${test_dev}" "${report_arg}"
 
 	echo "Unregister"
-	nvme resv-register "${test_dev}" --crkey=5 --rrega=1
+	nvme_resv register "${test_dev}" --crkey=5 --rrega=1
 	resv_report "${test_dev}" "${report_arg}"
 
 	echo "Acquire"
-	nvme resv-register "${test_dev}" --nrkey=4 --rrega=0
-	nvme resv-acquire "${test_dev}" --crkey=4 --rtype=1 --racqa=0
+	nvme_resv register "${test_dev}" --nrkey=4 --rrega=0
+	nvme_resv acquire "${test_dev}" --crkey=4 --rtype=1 --racqa=0
 	resv_report "${test_dev}" "${report_arg}"
 
 	echo "Preempt"
-	nvme resv-acquire "${test_dev}" --crkey=4 --prkey=4 --rtype=2 --racqa=1
+	nvme_resv acquire "${test_dev}" --crkey=4 --prkey=4 --rtype=2 --racqa=1
 	resv_report "${test_dev}" "${report_arg}"
 
 	echo "Release"
-	nvme resv-release "${test_dev}" --crkey=4 --rtype=2 --rrela=0
+	nvme_resv release "${test_dev}" --crkey=4 --rtype=2 --rrela=0
 	resv_report "${test_dev}" "${report_arg}"
 
 	echo "Clear"
-	nvme resv-acquire "${test_dev}" --crkey=4 --rtype=1 --racqa=0
+	nvme_resv acquire "${test_dev}" --crkey=4 --rtype=1 --racqa=0
 	resv_report "${test_dev}" "${report_arg}"
-	nvme resv-release "${test_dev}" --crkey=4 --rrela=1
+	nvme_resv release "${test_dev}" --crkey=4 --rrela=1
 }
 
 test() {

--- a/tests/nvme/054.out
+++ b/tests/nvme/054.out
@@ -54,5 +54,4 @@ regctlext[0] :
   cntlid     : ffff
   rcsts      : 1
   rkey       : 4
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/054.out
+++ b/tests/nvme/054.out
@@ -3,7 +3,6 @@ Register
 gen       : 0
 rtype     : 0
 regctl    : 0
-NVME Reservation  success
 gen       : 1
 rtype     : 0
 regctl    : 1
@@ -12,7 +11,6 @@ regctlext[0] :
   rcsts      : 0
   rkey       : 4
 Replace
-NVME Reservation  success
 gen       : 2
 rtype     : 0
 regctl    : 1
@@ -21,13 +19,10 @@ regctlext[0] :
   rcsts      : 0
   rkey       : 5
 Unregister
-NVME Reservation  success
 gen       : 3
 rtype     : 0
 regctl    : 0
 Acquire
-NVME Reservation  success
-NVME Reservation Acquire success
 gen       : 4
 rtype     : 1
 regctl    : 1
@@ -36,7 +31,6 @@ regctlext[0] :
   rcsts      : 1
   rkey       : 4
 Preempt
-NVME Reservation Acquire success
 gen       : 5
 rtype     : 2
 regctl    : 1
@@ -45,7 +39,6 @@ regctlext[0] :
   rcsts      : 1
   rkey       : 4
 Release
-NVME Reservation Release success
 gen       : 5
 rtype     : 0
 regctl    : 1
@@ -54,7 +47,6 @@ regctlext[0] :
   rcsts      : 0
   rkey       : 4
 Clear
-NVME Reservation Acquire success
 gen       : 5
 rtype     : 1
 regctl    : 1
@@ -62,6 +54,5 @@ regctlext[0] :
   cntlid     : ffff
   rcsts      : 1
   rkey       : 4
-NVME Reservation Release success
 disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/057.out
+++ b/tests/nvme/057.out
@@ -1,5 +1,4 @@
 Running nvme/057
 ANA failover
 ANA failback
-disconnected 4 controller(s)
 Test complete

--- a/tests/nvme/058.out
+++ b/tests/nvme/058.out
@@ -10,5 +10,4 @@ Remap namespace #7
 Remap namespace #8
 Remap namespace #9
 Remap namespace #10
-disconnected 6 controller(s)
 Test complete

--- a/tests/nvme/061.out
+++ b/tests/nvme/061.out
@@ -17,5 +17,4 @@ state: live
 iteration 5
 state: connecting
 state: live
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/062.out
+++ b/tests/nvme/062.out
@@ -1,10 +1,6 @@
 Running nvme/062
 Test unencrypted connection w/ tls not required
-disconnected 1 controller(s)
 Test encrypted connection w/ tls not required
-disconnected 1 controller(s)
 Test unencrypted connection w/ tls required (should fail)
-disconnected 0 controller(s)
 Test encrypted connection w/ tls required
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/063.out
+++ b/tests/nvme/063.out
@@ -1,7 +1,5 @@
 Running nvme/063
 Test secure concatenation with SHA256
 Reset controller
-disconnected 1 controller(s)
 Test secure concatenation with SHA384
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/065.out
+++ b/tests/nvme/065.out
@@ -1,4 +1,2 @@
 Running nvme/065
-disconnected 1 controller(s)
-disconnected 1 controller(s)
 Test complete

--- a/tests/nvme/068
+++ b/tests/nvme/068
@@ -52,7 +52,7 @@ test() {
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 	refcnt_orig=$(_module_use_count nvme_core)
 	echo 5 > "/sys/block/${ns}/delayed_removal_secs"
-	_nvme_disconnect_ctrl_sync "${nvmedev}" "${def_subsysnqn}"
+	_nvme_disconnect_ctrl "${nvmedev}"
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 	if [[ "${ns}" = "" ]]; then
 		echo "could not find ns after disconnect"
@@ -85,7 +85,7 @@ test() {
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 	refcnt_orig=$(_module_use_count nvme_core)
 	echo 5 > "/sys/block/${ns}/delayed_removal_secs"
-	_nvme_disconnect_ctrl_sync "${nvmedev}" "${def_subsysnqn}"
+	_nvme_disconnect_ctrl "${nvmedev}"
 	ns=$(_find_nvme_ns "${def_subsys_uuid}")
 	if [[ "${ns}" = "" ]]; then
 		echo "could not find ns after disconnect"


### PR DESCRIPTION
nvme-cli 3.x changes its output behavior to match standard POSIX tools. This means there is no output on success, and status and error messages are sent to stderr. For nvme commands, it is sufficient to check the return code to determine whether the command was successful.

By relying solely on the return code, backward compatibility with nvme-cli 2.x is also ensured.

Fixes: #247 
