### PR TITLE
block/045,046: add bio read-bounce alignment regression tests

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,4 @@
+/bio-full-trim
 /dio-offsets
 /discontiguous-io
 /loblksize

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,4 @@
+/bio-bounce-read
 /bio-full-trim
 /dio-offsets
 /discontiguous-io

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ HAVE_C_DEF = $(shell if echo -e "$(H)include <$(1)>\n$(H)ifdef $(2)\nHAVE_$(2)\n
 		then echo 1;else echo 0; fi)
 
 C_TARGETS := \
+	bio-full-trim \
 	dio-offsets \
 	loblksize \
 	loop_change_fd \

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,6 +13,7 @@ HAVE_C_DEF = $(shell if echo -e "$(H)include <$(1)>\n$(H)ifdef $(2)\nHAVE_$(2)\n
 		then echo 1;else echo 0; fi)
 
 C_TARGETS := \
+	bio-bounce-read \
 	bio-full-trim \
 	dio-offsets \
 	loblksize \

--- a/src/bio-bounce-read.c
+++ b/src/bio-bounce-read.c
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0+
+/* Copyright (C) 2026 0wnerD1ed */
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/io_uring.h>
+#include <linux/kernel-page-flags.h>
+#include <limits.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+static size_t page_size;
+
+#define PAGEMAP_PRESENT (1ULL << 63)
+#define PAGEMAP_PFN_MASK ((1ULL << 55) - 1)
+
+static void *map(size_t size, int prot)
+{
+	void *p = mmap(NULL, size, prot, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+	if (p == MAP_FAILED)
+		err(EXIT_FAILURE, "mmap");
+	return p;
+}
+
+static uint64_t read_u64(int fd, off_t offset, const char *name)
+{
+	uint64_t value;
+
+	if (pread(fd, &value, sizeof(value), offset) != sizeof(value))
+		err(EXIT_FAILURE, "%s", name);
+	return value;
+}
+
+static uint64_t pagemap_pfn(int fd, const void *p)
+{
+	uint64_t entry;
+	off_t offset = (uintptr_t)p / page_size * sizeof(entry);
+
+	entry = read_u64(fd, offset, "pagemap");
+	if (!(entry & PAGEMAP_PRESENT) || !(entry & PAGEMAP_PFN_MASK))
+		errx(EXIT_FAILURE, "pagemap PFN unavailable");
+	return entry & PAGEMAP_PFN_MASK;
+}
+
+static void pin_cpu(void)
+{
+	cpu_set_t set;
+	int cpu = sched_getcpu();
+
+	if (cpu < 0)
+		err(EXIT_FAILURE, "sched_getcpu");
+	CPU_ZERO(&set);
+	CPU_SET(cpu, &set);
+	if (sched_setaffinity(0, sizeof(set), &set))
+		err(EXIT_FAILURE, "sched_setaffinity");
+}
+
+static int bounce_read(const char *size, const char *path)
+{
+	struct io_uring_params params = {};
+	void *first, *middle, *bad;
+	struct iovec fixed, iov[3];
+	uint64_t first_pfn, flags;
+	unsigned long block_size;
+	int memfd, pagemap_fd, kpageflags_fd, ring_fd, fd;
+	ssize_t ret;
+
+	block_size = strtoul(size, NULL, 10);
+	if (!block_size || block_size > UINT_MAX || block_size > page_size ||
+	    (block_size & (block_size - 1)))
+		errx(EXIT_FAILURE, "invalid block size");
+	pin_cpu();
+
+	memfd = syscall(SYS_memfd_create, "bio-bounce", 0);
+	if (memfd < 0 || ftruncate(memfd, page_size))
+		err(EXIT_FAILURE, "memfd");
+	first = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, memfd,
+		     0);
+	if (first == MAP_FAILED)
+		err(EXIT_FAILURE, "mmap");
+	middle = map(block_size, PROT_READ | PROT_WRITE);
+	bad = map(block_size, PROT_NONE);
+	memset(first, 'A', page_size);
+	memset(middle, 'B', block_size);
+
+	pagemap_fd = open("/proc/self/pagemap", O_RDONLY);
+	if (pagemap_fd < 0)
+		err(EXIT_FAILURE, "pagemap");
+	first_pfn = pagemap_pfn(pagemap_fd, first);
+	kpageflags_fd = open("/proc/kpageflags", O_RDONLY);
+	if (kpageflags_fd < 0)
+		err(EXIT_FAILURE, "kpageflags");
+
+	ring_fd = syscall(SYS_io_uring_setup, 2, &params);
+	if (ring_fd < 0)
+		err(EXIT_FAILURE, "io_uring_setup");
+	fixed = (struct iovec){ first, page_size };
+	if (syscall(SYS_io_uring_register, ring_fd, IORING_REGISTER_BUFFERS,
+		    &fixed, 1) < 0)
+		err(EXIT_FAILURE, "io_uring_register");
+
+	iov[0] = (struct iovec){ first, 1 };
+	iov[1] = (struct iovec){ middle, block_size };
+	iov[2] = (struct iovec){ bad, block_size - 1 };
+	fd = open(path, O_RDONLY | O_DIRECT);
+	if (fd < 0)
+		err(EXIT_FAILURE, "open %s", path);
+	errno = 0;
+	ret = preadv(fd, iov, 3, 0);
+	if (ret != -1 || errno != EFAULT)
+		errx(EXIT_FAILURE, "preadv returned %zd (errno %d)", ret, errno);
+	close(fd);
+	munmap(first, page_size);
+	close(memfd);
+
+	flags = read_u64(kpageflags_fd, first_pfn * sizeof(flags),
+			 "kpageflags");
+	/*
+	 * The fixed-buffer pin must keep this page allocated. A page freed to a
+	 * Per-CPU Pageset (PCP) has no kpageflags, while a page drained to the
+	 * buddy allocator has KPF_BUDDY set. Either state shows that the page
+	 * was freed prematurely.
+	 */
+	if (!flags || (flags & (1ULL << KPF_BUDDY)))
+		errx(EXIT_FAILURE, "fixed-buffer page was freed (flags %#llx)",
+		     (unsigned long long)flags);
+
+	close(ring_fd);
+	close(kpageflags_fd);
+	close(pagemap_fd);
+	return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+	long size;
+
+	if (argc != 3)
+		return EXIT_FAILURE;
+	size = sysconf(_SC_PAGESIZE);
+	if (size <= 0)
+		errx(EXIT_FAILURE, "invalid page size");
+	page_size = size;
+	return bounce_read(argv[1], argv[2]);
+}

--- a/src/bio-full-trim.c
+++ b/src/bio-full-trim.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0+
+/* Copyright (C) 2026 0wnerD1ed */
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/fs.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+	unsigned int block_size;
+	unsigned char *p;
+	long page_size;
+	ssize_t ret;
+	int fd;
+
+	if (argc != 2)
+		return EXIT_FAILURE;
+	page_size = sysconf(_SC_PAGESIZE);
+	if (page_size <= 0)
+		errx(EXIT_FAILURE, "invalid page size");
+
+	fd = open(argv[1], O_RDONLY | O_DIRECT);
+	if (fd < 0)
+		err(EXIT_FAILURE, "open %s", argv[1]);
+	if (ioctl(fd, BLKSSZGET, &block_size))
+		err(EXIT_FAILURE, "BLKSSZGET");
+
+	p = mmap(NULL, 2 * page_size, PROT_READ | PROT_WRITE,
+		 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	if (p == MAP_FAILED)
+		err(EXIT_FAILURE, "mmap");
+	if (mprotect(p + page_size, page_size, PROT_NONE))
+		err(EXIT_FAILURE, "mprotect");
+
+	errno = 0;
+	ret = pread(fd, p + page_size - 1, block_size, 0);
+	if (ret == -1 && errno == EFAULT)
+		return EXIT_SUCCESS;
+	errx(EXIT_FAILURE, "pread returned %zd (errno %d)", ret, errno);
+}

--- a/tests/block/045
+++ b/tests/block/045
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0+
+# Copyright (C) 2026 0wnerD1ed
+#
+# Exercise the case where alignment removes the only extracted bvec. This
+# caught an out-of-bounds access in an intermediate revision of the patch that
+# became df308a145856 ("block: fix aligning of bounced dio read bios").
+
+. tests/block/rc
+. common/null_blk
+
+DESCRIPTION="test direct I/O full-trim bvec alignment"
+QUICK=1
+CAN_BE_ZONED=1
+
+requires() {
+	_have_null_blk
+}
+
+test() {
+	echo "Running ${TEST_NAME}"
+
+	if ! _configure_null_blk nullb1 power=1; then
+		echo "configuring null_blk failed"
+		return 1
+	fi
+
+	if ! src/bio-full-trim /dev/nullb1; then
+		echo "bio-full-trim helper failed"
+	fi
+
+	_exit_null_blk
+	echo "Test complete"
+}

--- a/tests/block/045.out
+++ b/tests/block/045.out
@@ -1,0 +1,2 @@
+Running block/045
+Test complete

--- a/tests/block/046
+++ b/tests/block/046
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0+
+# Copyright (C) 2026 0wnerD1ed
+#
+# Regression test for commit df308a145856 ("block: fix aligning of bounced dio
+# read bios"). Trigger a partial XFS direct read that used to unpin one user
+# page twice.
+
+. tests/block/rc
+. common/null_blk
+. common/xfs
+
+DESCRIPTION="test partial bounced direct read bvec alignment"
+QUICK=1
+
+requires() {
+	_have_xfs
+	_have_null_blk
+	_have_kernel_option IO_URING
+	_have_kernel_option PROC_PAGE_MONITOR
+}
+
+test() {
+	local block_size
+	local mount_dir="${TMPDIR}/mnt"
+	local test_file="${mount_dir}/target"
+
+	echo "Running ${TEST_NAME}"
+
+	if ! _configure_null_blk nullb1 size=300 memory_backed=1 power=1; then
+		echo "configuring null_blk failed"
+		return 1
+	fi
+	if ! echo 1 > /sys/block/nullb1/queue/stable_writes; then
+		SKIP_REASONS+=("null_blk does not support stable writes")
+		_exit_null_blk
+		return
+	fi
+	if ! _xfs_mkfs_and_mount /dev/nullb1 "${mount_dir}" \
+		>>"${FULL}" 2>&1; then
+		echo "failed to create and mount XFS"
+		_exit_null_blk
+		return
+	fi
+	dd if=/dev/zero of="${test_file}" bs=1M count=1 conv=fsync \
+		status=none
+	block_size=$(blockdev --getss /dev/nullb1)
+
+	_io_uring_enable
+	if ! src/bio-bounce-read "${block_size}" "${test_file}"; then
+		echo "bio-bounce-read helper failed"
+	fi
+	_io_uring_restore
+
+	umount "${mount_dir}" >>"${FULL}" 2>&1
+	rm -rf "${mount_dir}"
+	_exit_null_blk
+	echo "Test complete"
+}

--- a/tests/block/046.out
+++ b/tests/block/046.out
@@ -1,0 +1,2 @@
+Running block/046
+Test complete


### PR DESCRIPTION
## Summary

Add two regression tests for block-layer bvec alignment:

- `block/045` covers the boundary where alignment removes the only extracted bvec. It expects the direct read to fail with `EFAULT` without an out-of-bounds access.
- `block/046` covers the bounced direct-read double unpin. It keeps an io_uring fixed-buffer registration active and verifies that the registered page is not freed prematurely.

Both tests create and remove their own `null_blk` device, so no external test device is required.

## Background

Linux commit `e7b8b3c5b2a65595d506ffedafac66f0a11fbdc2` (`block: align down bounces bios`) introduced the bounced-read double unpin. Commit `df308a14585649f7683a560f5c94978ab4f8224d` (`block: fix aligning of bounced dio read bios`) fixes it.

`block/045` preserves a separate full-trim boundary case found while testing an intermediate revision of that fix. The intermediate loop accessed memory before the bvec array after consuming the final bvec; the issue was corrected before `df308a145856` was merged. Therefore both the final commit and its parent are expected to pass this test.

For `block/046`, the test creates a memory-backed `null_blk` device, enables `queue/stable_writes` before mounting XFS, and performs the partial direct read through the XFS read-bounce path.

The helper records the fixed-buffer page's PFN before the read. After triggering the partial extraction, it removes the userspace mapping while leaving the io_uring registration active and checks that PFN through `/proc/kpageflags`. On a vulnerable kernel the double unpin allows the page to enter a free-page state; with the fix applied, the io_uring pin keeps it allocated.

## Validation

- v7.2-rc5 with `df308a145856`: revised `block/046` setup passed 10/10 runs.
- v7.2-rc5 with `df308a145856` reverted: revised `block/046` setup failed 10/10 runs with `fixed-buffer page was freed (flags 0)`.
- `block/045` passed on v7.2-rc5 both with and without `df308a145856`, as expected for this boundary-only coverage.
- `block/045` passed with both normal and zoned self-configured `null_blk` devices after leaving the device at its default capacity.