### PR TITLE
Add ability to have multiple host ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /config
 /results
+cscope*
+tags

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,23 @@ all:
 
 clean:
 	$(MAKE) -C src clean
+	rm -f tags cscope.*
 
 install:
 	install -m755 -d $(dest)
 	install check $(dest)
 	cp -R tests common $(dest)
 	$(MAKE) -C src dest=$(dest)/src install
+
+tags: check_utility
+	@rm -f cscope.* tags
+	find . -type f -print | grep -v -E ".out|.git|.md|.files|.cmd|tags|LICENSES|.el|.jinja2|.py|results" > cscope.files
+	ctags -R --language-force=sh -L cscope.files --extras=+f
+	cscope -bq -I/usr/include
+
+check_utility:
+	@command -v ctags &>/dev/null || (echo "Error: 'ctags' not found in PATH." && exit 1)
+	@command -v cscope &>/dev/null || (echo "Error: 'cscope' not found in PATH." && exit 1)
 
 # SC2119: "Use foo "$@" if function's $1 should mean script's $1". False
 # positives on helpers like _init_scsi_debug.
@@ -36,4 +47,4 @@ check-parallel:
 	find -L -name '*.out' -perm /u=x+g=x+o=x -printf '%p is executable\n' | grep . && ret=1; \
 	exit $$ret
 
-.PHONY: all check check-parallel install
+.PHONY: all check check-parallel install tags check_utility

--- a/common/nvme
+++ b/common/nvme
@@ -1102,6 +1102,85 @@ _nvmet_target_setup() {
 			"${hostkey}" "${ctrlkey}"
 }
 
+_nvmet_target_add_ports() {
+	local ctrlkey=""
+	local hostkey=""
+	local subsysnqn="${def_subsysnqn}"
+	local subsys_uuid
+	local port p
+	local num_ports=1
+	local tls="none"
+	local cfs_path
+
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+			--ctrlkey)
+				ctrlkey="$2"
+				shift 2
+				;;
+			--hostkey)
+				hostkey="$2"
+				shift 2
+				;;
+			--subsysnqn)
+				subsysnqn="$2"
+				shift 2
+				;;
+			--subsys-uuid)
+				subsys_uuid="$2"
+				shift 2
+				;;
+			--ports)
+				num_ports="$2"
+				shift 2
+				;;
+			--tls)
+				tls="not-required"
+				shift 1
+				;;
+			--force-tls)
+				tls="required"
+				shift 1
+				;;
+			*)
+				echo "WARNING: unknown argument: $1"
+				shift
+				;;
+		esac
+	done
+
+	if [[ -n "${nvme_target_control}" ]]; then
+		if [[ -n "${hostkey}" ]]; then
+			ARGS+=(--hostkey "${hostkey}")
+		fi
+		if [[ -n "${ctrlkey}" ]]; then
+			ARGS+=(--ctrkey "${ctrlkey}")
+		fi
+
+		"${nvme_target_control}" add-ports \
+					 --ports "${num_ports}" \
+					 --subsysnqn "${subsysnqn}" \
+					 --subsys-uuid "${subsys_uuid:-$def_subsys_uuid}" \
+					 --hostnqn "${def_hostnqn}" \
+					 "${ARGS[@]}" &> /dev/null
+		echo "'${nvme_target_control} add-ports' is a stub"
+		return
+	fi
+
+	cfs_path="${NVMET_CFS}/subsystems/${subsystem}"
+	if [[ ! -d "${cfs_path}" ]]; then
+		echo "Can not add ports to a non-existent subsystem. subsystem not found"
+		return 1;
+	fi
+
+	p=0
+	while (( p < num_ports )); do
+		port="$(_create_nvmet_port ${tls})"
+		_add_nvmet_subsys_to_port "${port}" "${subsysnqn}"
+		p=$(( p + 1 ))
+	done
+}
+
 _nvmet_target_cleanup() {
 	local ports
 	local port

--- a/common/nvme
+++ b/common/nvme
@@ -30,6 +30,7 @@ NVMET_CFS="/sys/kernel/config/nvmet"
 NVMET_DFS="/sys/kernel/debug/nvmet"
 nvme_trtype=${nvme_trtype:-}
 nvme_adrfam=${nvme_adrfam:-}
+declare -ag ports_to_hosts
 
 # TMPDIR can not be referred out of test() or test_device() context. Instead of
 # global variable def_flie_path, use this getter function.
@@ -150,6 +151,7 @@ _cleanup_nvmet() {
 	local subsys
 	local transport
 	local name
+	local host_port
 
 	if [[ ! -d "${NVMET_CFS}" ]]; then
 		return 0
@@ -180,7 +182,9 @@ _cleanup_nvmet() {
 		name=$(basename "${port}")
 		echo "WARNING: Test did not clean up port: ${name}"
 		if [[ "${nvme_trtype}" == "fc" ]]; then
-			_nvme_fcloop_del_rport "${def_local_wwnn}" "${def_local_wwpn}" \
+			host_port="${ports_to_hosts[${name}]}"
+			_nvme_fcloop_del_rport "$(_host_wwnn "$host_port")" \
+					       "$(_host_wwpn "$host_port")" \
 					       "$(_remote_wwnn "$name")" \
 					       "$(_remote_wwpn "$name")"
 			_nvme_fcloop_del_tport "$(_remote_wwnn "$name")" \
@@ -212,7 +216,10 @@ _cleanup_nvmet() {
 	trap SIGINT
 
 	if [[ "${nvme_trtype}" == "fc" ]]; then
-		_nvme_fcloop_del_lport "${def_local_wwnn}" "${def_local_wwpn}"
+		for host_port in $(_get_fc_host_ports); do
+			_nvme_fcloop_del_lport "$(_host_wwnn "$host_port")" \
+					       "$(_host_wwpn "$host_port")"
+		done
 	fi
 	if [[ "${nvme_trtype}" == "rdma" ]]; then
 		stop_soft_rdma
@@ -222,6 +229,7 @@ _cleanup_nvmet() {
 }
 
 _setup_nvmet() {
+	local -i nr_host_ports=${1:-1}
 	_register_test_cleanup _cleanup_nvmet
 
 	if [[ -n "${nvme_target_control}" ]]; then
@@ -258,7 +266,9 @@ _setup_nvmet() {
 	fi
 	if [[ "${nvme_trtype}" = "fc" ]]; then
 		_load_module nvme-fcloop
-		_nvme_fcloop_add_lport "${def_local_wwnn}" "${def_local_wwpn}"
+		for ((i = 0; i < nr_host_ports; i++)); do
+			_nvme_fcloop_add_lport "$(_host_wwnn "$i")" "$(_host_wwpn "$i")"
+		done
 	fi
 }
 
@@ -563,16 +573,31 @@ _remote_wwpn() {
 	printf "0x%08x" $(( def_remote_wwpn + port ))
 }
 
+_host_wwnn() {
+	local -i port=${1}
+
+	printf "0x%08x" $(( def_local_wwnn + port ))
+}
+
+_host_wwpn() {
+	local -i port=${1}
+
+	printf "0x%08x" $(( def_local_wwpn + port ))
+}
+
 _fc_traddr() {
 	printf "nn-%s:pn-%s" "$(_remote_wwnn "$1")" "$(_remote_wwpn "$1")"
 }
 
 _fc_host_traddr() {
-	printf "nn-%s:pn-%s" "$def_local_wwnn" "$def_local_wwpn"
+	local -i port=${1:-0}
+
+	printf "nn-%s:pn-%s" "$(_host_wwnn $port)" "$(_host_wwpn $port)"
 }
 
 _create_nvmet_port() {
 	local tls="${1:-none}"
+	local host_port="${2:-0}"
 	local trtype="${nvme_trtype}"
 	local traddr="${def_traddr}"
 	local adrfam="${def_adrfam}"
@@ -596,7 +621,8 @@ _create_nvmet_port() {
 	elif [[ "${trtype}" == "fc" ]]; then
 		_nvme_fcloop_add_tport "$(_remote_wwnn $port)" \
 				       "$(_remote_wwpn $port)"
-		_nvme_fcloop_add_rport "$def_local_wwnn" "$def_local_wwpn" \
+		_nvme_fcloop_add_rport "$(_host_wwnn "$host_port")" \
+				       "$(_host_wwpn "$host_port")" \
 				       "$(_remote_wwnn $port)" \
 				       "$(_remote_wwpn $port)"
 		traddr=$(_fc_traddr $port)
@@ -638,13 +664,15 @@ _setup_nvmet_port_ana() {
 
 _remove_nvmet_port() {
 	local port="$1"
+	local host_port="${ports_to_hosts[${port}]}"
 	local cfsport="${NVMET_CFS}/ports/${port}"
 	local a
 
 	if [[ "${nvme_trtype}" == "fc" ]]; then
 		_nvme_fcloop_del_tport "$(_remote_wwnn "$port")" \
 				       "$(_remote_wwpn "$port")"
-		_nvme_fcloop_del_rport "$def_local_wwnn" "$def_local_wwpn" \
+		_nvme_fcloop_del_rport "$(_host_wwnn "$host_port")" \
+				       "$(_host_wwpn "$host_port")" \
 				       "$(_remote_wwnn "$port")" \
 				       "$(_remote_wwpn "$port")"
 	fi
@@ -920,9 +948,20 @@ _get_nvmet_ports() {
 	done
 }
 
+_get_fc_host_port() {
+	local -i port=${1}
+
+	echo "${ports_to_hosts[${port}]}"
+}
+
+_get_fc_host_ports() {
+	printf "%s\n" "${ports_to_hosts[@]}" | sort --unique
+}
+
 _get_nvmet_port_params() {
 	local port="$1"
 	local -n args="$2"
+	local host_port="${ports_to_hosts[${port}]}"
 	local cfs_path="${NVMET_CFS}/ports/${port}"
 	local trtype="${nvme_trtype}"
 	local traddr
@@ -952,7 +991,7 @@ _get_nvmet_port_params() {
 		;;
 	fc)
 		args+=(--traddr "$(_fc_traddr "$port")")
-		args+=(--host-traddr "$(_fc_host_traddr "$port")")
+		args+=(--host-traddr "$(_fc_host_traddr "$host_port")")
 		;;
 	*)
 		echo Unexpected transport type: "${trtype}"
@@ -1007,6 +1046,7 @@ _nvmet_target_setup() {
 	local port p
 	local resv_enable=""
 	local num_ports=1
+	local host_port=0
 	local tls="none"
 	local -a ARGS
 
@@ -1038,6 +1078,10 @@ _nvmet_target_setup() {
 				;;
 			--ports)
 				num_ports="$2"
+				shift 2
+				;;
+			--host_port)
+				host_port="$2"
 				shift 2
 				;;
 			--tls)
@@ -1077,6 +1121,12 @@ _nvmet_target_setup() {
 					 --subsys-uuid "${subsys_uuid:-$def_subsys_uuid}" \
 					 --hostnqn "${def_hostnqn}" \
 					 "${ARGS[@]}" &> /dev/null
+		p=0
+		while (( p < num_ports )); do
+			# Set ports_to_hosts so that _get_fc_host_port() can return the correct host port
+			ports_to_hosts+=("${host_port}")
+			p=$(( p + 1 ))
+		done
 		return
 	fi
 
@@ -1094,7 +1144,8 @@ _nvmet_target_setup() {
 
 	p=0
 	while (( p < num_ports )); do
-		port="$(_create_nvmet_port ${tls})"
+		port="$(_create_nvmet_port ${tls} "${host_port}")"
+		ports_to_hosts["${port}"]="${host_port}"
 		_add_nvmet_subsys_to_port "${port}" "${subsysnqn}"
 		p=$(( p + 1 ))
 	done
@@ -1109,6 +1160,7 @@ _nvmet_target_add_ports() {
 	local subsys_uuid
 	local port p
 	local num_ports=1
+	local host_port=0
 	local tls="none"
 	local cfs_path
 
@@ -1132,6 +1184,10 @@ _nvmet_target_add_ports() {
 				;;
 			--ports)
 				num_ports="$2"
+				shift 2
+				;;
+			--host_port)
+				host_port="$2"
 				shift 2
 				;;
 			--tls)
@@ -1163,6 +1219,12 @@ _nvmet_target_add_ports() {
 					 --subsys-uuid "${subsys_uuid:-$def_subsys_uuid}" \
 					 --hostnqn "${def_hostnqn}" \
 					 "${ARGS[@]}" &> /dev/null
+		p=0
+		while (( p < num_ports )); do
+			# Set ports_to_hosts so that _get_fc_host_port() can return the correct host port
+			ports_to_hosts+=("${host_port}")
+			p=$(( p + 1 ))
+		done
 		echo "'${nvme_target_control} add-ports' is a stub"
 		return
 	fi
@@ -1175,7 +1237,8 @@ _nvmet_target_add_ports() {
 
 	p=0
 	while (( p < num_ports )); do
-		port="$(_create_nvmet_port ${tls})"
+		port="$(_create_nvmet_port ${tls} "${host_port}")"
+		ports_to_hosts["${port}"]="${host_port}"
 		_add_nvmet_subsys_to_port "${port}" "${subsysnqn}"
 		p=$(( p + 1 ))
 	done
@@ -1183,6 +1246,7 @@ _nvmet_target_add_ports() {
 
 _nvmet_target_cleanup() {
 	local ports
+	local host_port
 	local port
 	local blkdev
 	local subsysnqn="${def_subsysnqn}"

--- a/contrib/nvme_target_control.py
+++ b/contrib/nvme_target_control.py
@@ -117,6 +117,11 @@ def target_setup(args):
     subprocess.call(['python3', nvmetcli, '--remote=' + remote,
                      'restore', args.subsysnqn + '.json'])
 
+def target_add_ports(_):
+    if config['main']['skip_setup_cleanup']:
+        return
+
+    print("Warning: add-ports is not implemented yet.")
 
 def target_cleanup(args):
     if config['main']['skip_setup_cleanup']:
@@ -158,6 +163,15 @@ def build_parser():
     setup.add_argument('--ctrlkey', default='')
     setup.add_argument('--hostkey', default='')
     setup.set_defaults(func=target_setup)
+
+    setup = sub.add_parser('add-ports')
+    setup.add_argument('--ports', required=True)
+    setup.add_argument('--subsysnqn', required=True)
+    setup.add_argument('--subsys-uuid', required=True)
+    setup.add_argument('--hostnqn', required=True)
+    setup.add_argument('--ctrlkey', default='')
+    setup.add_argument('--hostkey', default='')
+    setup.set_defaults(func=target_add_ports)
 
     cleanup = sub.add_parser('cleanup')
     cleanup.add_argument('--subsysnqn', required=True)


### PR DESCRIPTION
# Add various features namely the ability to have multiple host ports 

This will be used in my upcoming PR for testing nvme marginal support.
All the commits are independent of one-anther, if anyone thinks its a good idea
to split them into multiple PRs I can .

### makefile: Add rules to generate ctags
    
    If cscope and ctags are installed create the databases needed
    to browse these shell scripts with cscope/ctags.

### nvme: Add ability to have multiple host ports
    
    Currently, the nvme tests only support a single host port.
    This patch adds the ability to have multiple host ports, which will
    more accuratly reflect a real-world multipath scenario.

### nvme: Add _nvmet_target_add_ports
    
    Add `_nvmet_target_add_ports` to allow for more ports to be added after
    `_nvmet_target_setup` has been called.
    