### PR TITLE
nvme: rename DH to KX according TP4201

### DIFF
--- a/common/nvme
+++ b/common/nvme
@@ -37,6 +37,60 @@ _nvme_def_file_path() {
 	echo "${TMPDIR}/img"
 }
 
+_nvme_kxchap_cmd_style() {
+	if [[ -z "${_nvme_kxchap_style:-}" ]]; then
+		if nvme keys gen-kxchap --nqn nvmf-test-subsys > /dev/null 2>&1; then
+			_nvme_kxchap_style="3"
+		elif nvme gen-dhchap-key --nqn nvmf-test-subsys > /dev/null 2>&1; then
+			_nvme_kxchap_style="2"
+		else
+			_nvme_kxchap_style="none"
+		fi
+	fi
+}
+
+_nvme_tls_cmd_style() {
+	if [[ -z "${_nvme_tls_style:-}" ]]; then
+		if nvme keys gen-tls --subsysnqn nvmf-test-subsys > /dev/null 2>&1; then
+			_nvme_tls_style="3"
+		elif nvme gen-tls-key --subsysnqn nvmf-test-subsys > /dev/null 2>&1; then
+			_nvme_tls_style="2"
+		else
+			_nvme_tls_style="none"
+		fi
+	fi
+}
+
+_nvme_gen_kxchap_key() {
+	_nvme_kxchap_cmd_style
+	case "$_nvme_kxchap_style" in
+	3)
+		nvme keys gen-kxchap "$@"
+		;;
+	2)
+		nvme gen-dhchap-key "$@"
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+_nvme_gen_tls_key() {
+	_nvme_tls_cmd_style
+	case "$_nvme_tls_style" in
+	3)
+		nvme keys gen-tls "$@"
+		;;
+	2)
+		nvme gen-tls-key "$@"
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
 _require_nvme_trtype() {
 	local trtype
 	for trtype in "$@"; do

--- a/tests/nvme/041
+++ b/tests/nvme/041
@@ -30,9 +30,9 @@ test() {
 	local hostkey
 	local ctrldev
 
-	hostkey="$(nvme gen-dhchap-key -n "${def_subsysnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
-		echo "nvme gen-dhchap-key failed"
+		echo "key generation failed"
 		return 1
 	fi
 

--- a/tests/nvme/042
+++ b/tests/nvme/042
@@ -36,7 +36,7 @@ test() {
 
 	for hmac in 0 1 2 3; do
 		echo "Testing hmac ${hmac}"
-		hostkey="$(nvme gen-dhchap-key --hmac=${hmac} -n "${def_subsysnqn}" 2> /dev/null)"
+		hostkey="$(_nvme_gen_kxchap_key --hmac=${hmac} --nqn "${def_subsysnqn}" 2> /dev/null)"
 		if [ -z "$hostkey" ] ; then
 			echo "couldn't generate host key for hmac ${hmac}"
 			return 1
@@ -50,7 +50,7 @@ test() {
 
 	for key_len in 32 48 64; do
 		echo "Testing key length ${key_len}"
-		hostkey="$(nvme gen-dhchap-key --key-length=${key_len} -n "${def_subsysnqn}" 2> /dev/null)"
+		hostkey="$(_nvme_gen_kxchap_key --key-length=${key_len} --nqn "${def_subsysnqn}" 2> /dev/null)"
 		if [ -z "$hostkey" ] ; then
 			echo "couldn't generate host key for length ${key_len}"
 			return 1

--- a/tests/nvme/043
+++ b/tests/nvme/043
@@ -33,9 +33,9 @@ test() {
 	local hostkey
 	local ctrldev
 
-	hostkey="$(nvme gen-dhchap-key -n "${def_hostnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_hostnqn}" 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
-		echo "nvme gen-dhchap-key failed"
+		echo "key generation failed"
 		return 1
 	fi
 

--- a/tests/nvme/044
+++ b/tests/nvme/044
@@ -32,13 +32,13 @@ test() {
 	local ctrlkey
 	local ctrldev
 
-	hostkey="$(nvme gen-dhchap-key -n "${def_subsysnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "failed to generate host key"
 		return 1
 	fi
 
-	ctrlkey="$(nvme gen-dhchap-key -n "${def_subsysnqn}" 2> /dev/null)"
+	ctrlkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
 	if [ -z "$ctrlkey" ] ; then
 		echo "failed to generate ctrl key"
 		return 1

--- a/tests/nvme/045
+++ b/tests/nvme/045
@@ -37,13 +37,13 @@ test() {
 	local rand_io_size
 	local ns
 
-	hostkey="$(nvme gen-dhchap-key -n "${def_subsysnqn}" 2> /dev/null)"
+	hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
 	if [ -z "$hostkey" ] ; then
 		echo "failed to generate host key"
 		return 1
 	fi
 
-	ctrlkey="$(nvme gen-dhchap-key -n "${def_subsysnqn}" 2> /dev/null)"
+	ctrlkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
 	if [ -z "$ctrlkey" ] ; then
 		echo "failed to generate ctrl key"
 		return 1
@@ -68,7 +68,7 @@ test() {
 
 	echo "Renew host key on the controller"
 
-	new_hostkey="$(nvme gen-dhchap-key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	new_hostkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
 
 	_set_nvmet_hostkey "${def_hostnqn}" "${new_hostkey}"
 
@@ -78,7 +78,7 @@ test() {
 
 	echo "Renew ctrl key on the controller"
 
-	new_ctrlkey="$(nvme gen-dhchap-key --nqn "${def_subsysnqn}" 2> /dev/null)"
+	new_ctrlkey="$(_nvme_gen_kxchap_key --nqn "${def_subsysnqn}" 2> /dev/null)"
 
 	_set_nvmet_ctrlkey "${def_hostnqn}" "${new_ctrlkey}"
 

--- a/tests/nvme/062
+++ b/tests/nvme/062
@@ -32,9 +32,9 @@ test() {
 	local hostkey
 	local ctrl
 
-	hostkey=$(nvme gen-tls-key -n "${def_hostnqn}" -c "${def_subsysnqn}" -m 1 -I 1 -i 2> /dev/null)
+	hostkey=$(_nvme_gen_tls_key -n "${def_hostnqn}" -c "${def_subsysnqn}" -m 1 -I 1 -i 2> /dev/null)
 	if [ -z "$hostkey" ] ; then
-		echo "nvme gen-tls-key failed"
+		echo "TLS key generation failed"
 		return 1
 	fi
 

--- a/tests/nvme/063
+++ b/tests/nvme/063
@@ -34,9 +34,9 @@ test() {
 
 	_systemctl_start tlshd
 
-	hostkey=$(nvme gen-dhchap-key -m 1 -n "${def_hostnqn}" 2> /dev/null)
+	hostkey=$(_nvme_gen_kxchap_key --hmac 1 --nqn "${def_hostnqn}" 2> /dev/null)
 	if [ -z "$hostkey" ] ; then
-		echo "nvme gen-dhchap-key failed"
+		echo "key generation failed"
 		_systemctl_stop
 		return 1
 	fi
@@ -76,9 +76,9 @@ test() {
 
 	_nvme_disconnect_subsys
 
-	hostkey=$(nvme gen-dhchap-key -m 2 -n "${def_hostnqn}" 2> /dev/null)
+	hostkey=$(_nvme_gen_kxchap_key --hmac 2 --nqn "${def_hostnqn}" 2> /dev/null)
 	if [ -z "$hostkey" ] ; then
-		echo "nvme gen-dhchap-key failed"
+		echo "key generation failed"
 		_systemctl_stop
 		return 1
 	fi

--- a/tests/nvme/rc
+++ b/tests/nvme/rc
@@ -100,16 +100,18 @@ _require_test_dev_support_sed() {
 }
 
 _require_nvme_cli_auth() {
-	if ! nvme gen-dhchap-key --nqn nvmf-test-subsys > /dev/null 2>&1 ; then
-		SKIP_REASONS+=("nvme gen-dhchap-key command missing")
+	_nvme_kxchap_cmd_style
+	if [[ "$_nvme_kxchap_style" == "none" ]]; then
+		SKIP_REASONS+=("nvme gen-dhchap-key / nvme keys gen-kxchap command missing")
 		return 1
 	fi
 	return 0
 }
 
 _require_nvme_cli_tls() {
-	if ! nvme gen-tls-key --subsysnqn nvmf-test-subsys > /dev/null 2>&1; then
-		SKIP_REASONS+=("nvme gen-tls-key command missing")
+	_nvme_tls_cmd_style
+	if [[ "$_nvme_tls_style" == "none" ]]; then
+		SKIP_REASONS+=("nvme gen-tls-key / nvme keys gen-tls command missing")
 		return 1
 	fi
 	return 0


### PR DESCRIPTION
The DH (Diffie Hellman) prefix is replaced with KX (key exchange) as defined in TP4201 Enhancements for Post-Quantum Crypto Algorithms.

Rename all blktests internal function, arguments accordingly.

nvme-cli 3 is deprecating and replaces them with sub commands
- `nvme check-dhchap-key` -> `nvme keys check-kxchap`
- `nvme check-tls-key`-> `nvme keys check-tls`
- `nvme gen-dhchap-key` -> `nvme keys gen-kxchap`
- `nvme gen-tls-key` -> `nvme keys gen-tls`
- `nvme tls-key` -> `nvme keys import`, `nvme keys export`, `nvme keys revoke`

nvme-cli 3.x also supports the new naming scheme, thus auto detect it and use the 'keys' plugin which uses the new naming scheme.