### PR TITLE
loop: test partition cleanup when the backing file is changed

### DIFF
--- a/tests/loop/014
+++ b/tests/loop/014
@@ -1,0 +1,76 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-3.0+
+# Copyright (C) 2026 Daan De Meyer
+#
+# Verify that partitions added manually with BLKPG do not survive a
+# LOOP_CHANGE_FD on a loop device without LO_FLAGS_PARTSCAN.
+#
+# Regression test for commit "loop: drop stale partitions on LOOP_CHANGE_FD".
+
+. tests/loop/rc
+
+DESCRIPTION="remove manually added partitions when the backing file is changed"
+QUICK=1
+
+loop_device=
+udevd_stopped=
+
+requires() {
+	_have_src_program loop_change_fd
+	_have_program sfdisk
+	_have_program partx
+}
+
+cleanup() {
+	if [[ -n "$loop_device" ]]; then
+		losetup --detach "$loop_device" &>/dev/null
+	fi
+	if [[ -n "$udevd_stopped" ]]; then
+		_systemd_start_udevd
+	fi
+}
+
+test() {
+	echo "Running ${TEST_NAME}"
+	_register_test_cleanup cleanup
+
+	# LOOP_CHANGE_FD requires both backing files to have the same size. The
+	# new one is left without a partition table so that nothing can recreate
+	# the partition of the old one.
+	truncate --size=3MiB "$TMPDIR/old"
+	truncate --size=3MiB "$TMPDIR/new"
+	sfdisk "$TMPDIR/old" >"$FULL" 2>&1 <<-EOF
+		label: gpt
+		size=1MiB
+	EOF
+
+	# Keep userspace from removing the partition on our behalf.
+	if _systemctl_unit_is_active systemd-udevd; then
+		_systemd_stop_udevd
+		udevd_stopped=1
+	fi
+
+	# LOOP_CHANGE_FD only works on read-only loop devices.
+	if ! loop_device="$(losetup --read-only --find --show "$TMPDIR/old")"; then
+		echo "Failed to configure loop device"
+		echo "Test complete"
+		return
+	fi
+	local name="${loop_device##*/}"
+	local partition="/sys/block/$name/${name}p1"
+
+	# Add a partition without setting LO_FLAGS_PARTSCAN on the loop device.
+	if ! partx --add "$loop_device" >>"$FULL" 2>&1; then
+		echo "Failed to add partition"
+	elif [[ ! -e "$partition" ]]; then
+		echo "Partition was not created"
+	fi
+
+	if ! src/loop_change_fd "$loop_device" "$TMPDIR/new" >>"$FULL" 2>&1; then
+		echo "Failed to change the backing file"
+	elif [[ -e "$partition" ]]; then
+		echo "Partition still exists after the backing file was changed"
+	fi
+
+	echo "Test complete"
+}

--- a/tests/loop/014.out
+++ b/tests/loop/014.out
@@ -1,0 +1,2 @@
+Running loop/014
+Test complete


### PR DESCRIPTION
Partitions can be added to a loop device with BLKPG while
LO_FLAGS_PARTSCAN is clear. loop_change_fd() only rescanned when
LO_FLAGS_PARTSCAN was set, so once disk_force_media_change() stopped
setting GD_NEED_PART_SCAN such partitions survived the backing file swap
and kept describing the old file.

Add a regression test that adds a partition with partx to a read-only
loop device, swaps in a backing file of the same size without a partition
table, and verifies that the partition is gone afterwards. Stop an active
systemd-udevd during the test so userspace cannot hide missing kernel
cleanup, and restore it through the test cleanup hook.

Signed-off-by: Daan De Meyer <daan@amutable.com>
