### PR TITLE
README.md: Require nvme-cli >= 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The dependencies are minimal, but make sure you have them installed:
 Some tests require the following:
 
 - e2fsprogs, xfsprogs, f2fs-tools and btrfs-progs
-- nvme-cli
+- nvme-cli (>= 3.0)
 - multipath-tools (Debian, openSUSE, Arch Linux) or device-mapper-multipath
   (Fedora)
 - nbd-client and nbd-server (Debian) or nbd (Fedora, openSUSE, Arch Linux)


### PR DESCRIPTION
Commit df7cf50409ce ("nvme: rely on nvme-cli status code") changed nvme-cli to use the exit code to determine the result of the command, which is only available in nvme-cli >= 3.0. This commit updates the readme to match this requirement.