### PR TITLE
fix(dio-offsets.c): include necessary header to compile

### DIFF
--- a/src/dio-offsets.c
+++ b/src/dio-offsets.c
@@ -15,6 +15,7 @@
 #include <libgen.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixes 07af8a0e2383f99a50ff5340497eda9a4b0d9cac

commit 07af8a0 used fixed-width data type without including the necessary header. This results in compilation failure in my environment

When `make` is run, it throws the following error.
```
make -C src all
make[1]: Entering directory '/home/ec2-user/blktests/src'
Skip miniublk build due to missing kernel header(v6.0+)
cc  -O2 -Wall -Wshadow  -DHAVE_LINUX_BLKZONED_H  -o bio-bounce-read bio-bounce-read.c
cc  -O2 -Wall -Wshadow  -DHAVE_LINUX_BLKZONED_H  -o bio-full-trim bio-full-trim.c
cc  -O2 -Wall -Wshadow  -DHAVE_LINUX_BLKZONED_H  -o dio-offsets dio-offsets.c
dio-offsets.c: In function ‘__compare’:
dio-offsets.c:137:23: error: ‘uint8_t’ undeclared (first use in this function)
  137 |                 if (((uint8_t *)a)[i] != ((uint8_t *)b)[i])
      |                       ^~~~~~~

[...] Truncated Suggested fix for brevity
                                                    ^
make[1]: *** [Makefile:82: dio-offsets] Error 1
make[1]: Leaving directory '/home/ec2-user/blktests/src'
make: *** [Makefile:5: all] Error 2
```